### PR TITLE
Fix issues found from running cages

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -76,7 +76,7 @@ module.exports = (config) => {
       JSON.stringify({
         cageData: encryptedKey,
         keyIv,
-        encryptedData,
+        sharedEncryptedData: encryptedData,
       })
     );
     return `${header}.${payload}.${uuid()}`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,10 @@ class EvervaultClient {
   async encrypt(data, options) {
     if (!Datatypes.isDefined(this._cageKey)) {
       const cageKeyResponse = await this.http.getCageKey();
-      this.defineHiddenProperty('_cageKey', cageKeyResponse.key);
+      this.defineHiddenProperty(
+        '_cageKey',
+        Datatypes.formatKey(cageKeyResponse.key)
+      );
     }
     return await this.crypto.encrypt(this._cageKey, data, options || {});
   }

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -24,6 +24,15 @@ const ensureString = (data) => {
 const base64ToBuffer = (data) => Buffer.from(data, 'base64');
 const utf8ToBase64 = (data) => Buffer.from(data, 'utf8').toString('base64');
 
+const KEY_HEADER = '-----BEGIN PUBLIC KEY-----\n';
+const KEY_FOOTER = '-----END PUBLIC KEY-----';
+const formatKey = (key) => {
+  if (key.includes(KEY_HEADER) && key.includes(KEY_FOOTER)) {
+    return key;
+  }
+  return `${KEY_HEADER}${key.match(/.{0,64}/g).join('\n')}${KEY_FOOTER}`;
+};
+
 module.exports = {
   isArray,
   isObject,
@@ -35,4 +44,5 @@ module.exports = {
   ensureString,
   base64ToBuffer,
   utf8ToBase64,
+  formatKey,
 };

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -93,7 +93,7 @@ describe('Initialising the sdk', () => {
         return sdk.encrypt(testData).then(() => {
           expect(cageKeyNock.isDone()).to.be.true;
           expect(encryptStub).to.have.been.calledWith(
-            testCageKey,
+            `-----BEGIN PUBLIC KEY-----\n${testCageKey}\n-----END PUBLIC KEY-----`,
             testData,
             {}
           );
@@ -121,7 +121,7 @@ describe('Initialising the sdk', () => {
         return sdk.encrypt(testData).then(() => {
           expect(getCageKeyStub).to.have.been.calledOnce;
           expect(encryptStub).to.always.have.been.calledWith(
-            testCageKey,
+            `-----BEGIN PUBLIC KEY-----\n${testCageKey}\n-----END PUBLIC KEY-----`,
             testData,
             {}
           );
@@ -159,7 +159,7 @@ describe('Initialising the sdk', () => {
         return sdk.encryptAndRun(cageName, testData).then(() => {
           expect(getCageKeyStub).to.have.been.calledOnce;
           expect(encryptStub).to.have.been.calledOnceWith(
-            testCageKey,
+            `-----BEGIN PUBLIC KEY-----\n${testCageKey}\n-----END PUBLIC KEY-----`,
             testData,
             {}
           );

--- a/tests/utilities/keyService.mock.js
+++ b/tests/utilities/keyService.mock.js
@@ -34,14 +34,14 @@ module.exports = () => {
       base64ToBuffer(parsedData.cageData)
     );
 
-    const { encryptedData, keyIv } = parsedData;
+    const { sharedEncryptedData, keyIv } = parsedData;
     const decipher = crypto.createDecipheriv(
       'aes-256-gcm',
       encryptionKey,
       base64ToBuffer(keyIv)
     );
 
-    const dataBuffer = Buffer.from(encryptedData, 'base64');
+    const dataBuffer = Buffer.from(sharedEncryptedData, 'base64');
     const authTagFirstByte = dataBuffer.byteLength - 16;
     const authTag = dataBuffer.slice(authTagFirstByte);
     const trimmedData = dataBuffer.slice(0, authTagFirstByte);


### PR DESCRIPTION
# Why
Runtime is looking for the data as `sharedEncryptedData`, but it was being given as `encryptedData`. Public keys are stored without headers and footers, so added a key formatter.

# How
add sharedEncryptedData key, format public keys to work with node crypto