### PR TITLE
Use base64url in the node sdk

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -71,8 +71,8 @@ module.exports = (config) => {
   };
 
   const _format = (encryptedKey, keyIv, encryptedData) => {
-    const header = Datatypes.utf8ToBase64(JSON.stringify(config.header));
-    const payload = Datatypes.utf8ToBase64(
+    const header = Datatypes.utf8ToBase64Url(JSON.stringify(config.header));
+    const payload = Datatypes.utf8ToBase64Url(
       JSON.stringify({
         cageData: encryptedKey,
         keyIv,

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -26,7 +26,7 @@ const base64ToBase64Url = (base64String) => {
 };
 
 const base64ToBuffer = (data) => Buffer.from(data, 'base64');
-const utf8ToBase64 = (data) => {
+const utf8ToBase64Url = (data) => {
   const base64 = Buffer.from(data, 'utf8').toString('base64');
   return base64ToBase64Url(base64);
 };
@@ -50,6 +50,6 @@ module.exports = {
   isUndefined,
   ensureString,
   base64ToBuffer,
-  utf8ToBase64,
+  utf8ToBase64Url,
   formatKey,
 };

--- a/tests/datatypes.test.js
+++ b/tests/datatypes.test.js
@@ -185,4 +185,16 @@ describe('Datatypes', () => {
       });
     });
   });
+
+  describe('utf8ToBase64Url', () => {
+    const testString = 'test me boi';
+    it('Base64 url encodes the string', () => {
+      const base64Url = Datatypes.utf8ToBase64Url(testString);
+      expect(base64Url).to.not.contain('+');
+      expect(base64Url).to.not.contain('/');
+      expect(base64Url).to.match(/[a-zA-Z0-9-_=]/);
+      const decoded = Buffer.from(base64Url, 'base64').toString('utf8');
+      expect(decoded).to.equal(testString);
+    });
+  });
 });


### PR DESCRIPTION
# Why
Use base64Url instead of base64 - allow for wider usage (won't break in a url)

# How
Add a base64ToBase64Url function. Add a test to make sure it can be decoded to a buffer as base64 with tests.