### PR TITLE
Remove data from the cage run POST body

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -29,7 +29,7 @@ module.exports = (config) => {
 
   const runCage = (cageName, payload) =>
     post(`cages/${cageName}`, {
-      data: payload,
+      payload,
     });
 
   return { getCageKey, runCage };


### PR DESCRIPTION
Depends on [#645 in the API](https://github.com/evervault/api/pull/645).

# Why
The API now automatically passed the payload to the lambda in the `data` key so we don't have to stick it in manually.

# How
The code is pretty... simple.