### PR TITLE
update encryption to put datatype in header

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -16,23 +16,29 @@ const DEFAULT_ENCRYPT_OPTIONS = {
 };
 
 module.exports = (config) => {
-  const _encryptObject = async (cageKey, data, { fieldsToEncrypt }) => {
-    const keys = fieldsToEncrypt || Object.keys(data);
-    const encryptedObject = { ...data };
-    for (let key of keys) {
-      if (Datatypes.isUndefined(data[key])) {
-        encryptedObject[key] = data[key];
-      } else {
-        encryptedObject[key] = await _encryptString(
-          cageKey,
-          Datatypes.ensureString(data[key])
-        );
-      }
-    }
-    return encryptedObject;
+  const _encryptObject = async (cageKey, data) => {
+    return await _traverseObject(cageKey, { ...data });
   };
 
-  const _encryptString = async (cageKey, str) => {
+  const _traverseObject = async (cageKey, data) => {
+    if (Datatypes.isEncryptable(data)) {
+      return await _encryptString(
+        cageKey,
+        Datatypes.ensureString(data),
+        Datatypes.getHeaderType(data)
+      );
+    } else if (Datatypes.isObjectStrict(data)) {
+      const encryptedObject = { ...data };
+      for (let [key, value] of Object.entries(encryptedObject)) {
+        encryptedObject[key] = await _traverseObject(cageKey, value);
+      }
+      return encryptedObject;
+    } else {
+      return data;
+    }
+  };
+
+  const _encryptString = async (cageKey, str, datatype) => {
     const keyIv = await generateBytes(config.keyLength / 2);
     const rootKey = await generateBytes(config.keyLength);
     const cipher = crypto.createCipheriv(
@@ -53,6 +59,7 @@ module.exports = (config) => {
     const encryptedKey = _publicEncrypt(cageKey, rootKey);
 
     return _format(
+      datatype,
       encryptedKey.toString('base64'),
       keyIv.toString('base64'),
       encryptedBuffer.toString('base64')
@@ -69,8 +76,10 @@ module.exports = (config) => {
     );
   };
 
-  const _format = (encryptedKey, keyIv, encryptedData) => {
-    const header = Datatypes.utf8ToBase64Url(JSON.stringify(config.header));
+  const _format = (datatype, encryptedKey, keyIv, encryptedData) => {
+    const header = Datatypes.utf8ToBase64Url(
+      JSON.stringify({ ...config.header, datatype })
+    );
     const payload = Datatypes.utf8ToBase64Url(
       JSON.stringify({
         cageData: encryptedKey,
@@ -91,8 +100,14 @@ module.exports = (config) => {
 
     if (Datatypes.isObjectStrict(data)) {
       return await _encryptObject(key, data, options);
+    } else if (Datatypes.isEncryptable(data)) {
+      return await _encryptString(
+        key,
+        Datatypes.ensureString(data),
+        Datatypes.getHeaderType(data)
+      );
     } else {
-      return await _encryptString(key, Datatypes.ensureString(data));
+      throw new Error("Data supplied isn't encryptable");
     }
   };
 

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -4,8 +4,22 @@ const isObject = (data) => typeof data === 'object';
 const isObjectStrict = (data) =>
   isDefined(data) && isObject(data) && !isArray(data) && !isBuffer(data);
 const isString = (data) => typeof data === 'string';
+const isNumber = (data) => typeof data === 'number';
 const isDefined = (data) => typeof data !== 'undefined' && data !== null;
 const isUndefined = (data) => typeof data === 'undefined';
+const isBoolean = (data) => typeof data === 'boolean';
+
+const isEncryptable = (data) =>
+  isDefined(data) &&
+  (isArray(data) || isString(data) || isNumber(data) || isBoolean(data));
+
+const getHeaderType = (data) => {
+  if (!isDefined(data)) return;
+  if (isArray(data)) return data.constructor.name;
+  else {
+    return typeof data;
+  }
+};
 
 const ensureString = (data) => {
   if (isUndefined(data)) return;
@@ -46,6 +60,8 @@ module.exports = {
   isObjectStrict,
   isBuffer,
   isString,
+  isEncryptable,
+  getHeaderType,
   isDefined,
   isUndefined,
   ensureString,

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -12,14 +12,15 @@ Crypto.__set__({
 const testApiKey = 'test-api-key';
 const testConfig = require('../../lib/config')(testApiKey).encryption;
 
-const encryptedDataExpectations = (encrypted) => {
+const encryptedDataExpectations = (encrypted, datatype) => {
   expect(encrypted).to.be.a('string');
   expect(encrypted.split('.').length).to.equal(3);
   const [header, _, uuid] = encrypted.split('.');
   expect(uuid).to.equal(testingUuid);
-  expect(dataHelpers.parseBase64ToJson(header)).to.deep.equal(
-    testConfig.header
-  );
+  expect(dataHelpers.parseBase64ToJson(header)).to.deep.equal({
+    ...testConfig.header,
+    datatype,
+  });
 };
 
 describe('Crypto Module', () => {
@@ -31,9 +32,9 @@ describe('Crypto Module', () => {
 
     it('Returns the encrypted string in the ev string format', () => {
       return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        encryptedDataExpectations(encrypted);
-        const { body } = dataHelpers.parseEncryptedData(encrypted);
-        expect(MockCageService.decrypt(body)).to.deep.equal(testData);
+        encryptedDataExpectations(encrypted, 'string');
+        const { header, body } = dataHelpers.parseEncryptedData(encrypted);
+        expect(MockCageService.decrypt(header, body)).to.deep.equal(testData);
       });
     });
   });
@@ -49,72 +50,30 @@ describe('Crypto Module', () => {
     };
 
     context('Preserve object shape set to true', () => {
-      context('No fieldsToEncrypt provided', () => {
-        const encryptionOptions = { preserveObjectShape: true };
-        it('It encrypts every field', () => {
-          return testCryptoClient
-            .encrypt(testKey, testData, encryptionOptions)
-            .then((encrypted) => {
-              expect(Object.keys(encrypted)).to.deep.equal(
-                Object.keys(testData)
-              );
+      it('It encrypts every field', () => {
+        return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
+          expect(Object.keys(encrypted)).to.deep.equal(Object.keys(testData));
+          const testObjectKey = (key) => {
+            const { header, body } = dataHelpers.parseEncryptedData(
+              encrypted[key]
+            );
+            expect(MockCageService.decrypt(header, body)).to.deep.equal(
+              testData[key]
+            );
+          };
 
-              Object.keys(encrypted).forEach((objectKey) => {
-                encryptedDataExpectations(encrypted[objectKey]);
-                const { body } = dataHelpers.parseEncryptedData(
-                  encrypted[objectKey]
-                );
-                expect(MockCageService.decrypt(body)).to.deep.equal(
-                  testData[objectKey]
-                );
-              });
-            });
+          encryptedDataExpectations(encrypted.a, 'number');
+          testObjectKey('a');
+          encryptedDataExpectations(encrypted.b, 'string');
+          testObjectKey('b');
+          encryptedDataExpectations(encrypted.c.arr, 'Array');
+          const { header, body } = dataHelpers.parseEncryptedData(
+            encrypted.c.arr
+          );
+          expect(MockCageService.decrypt(header, body)).to.deep.equal(
+            testData.c.arr
+          );
         });
-      });
-      context('FieldsToEncrypt specified', () => {
-        const testFieldsToEncrypt = ['a', 'b'];
-        const encryptionOptions = {
-          preserveObjectShape: true,
-          fieldsToEncrypt: testFieldsToEncrypt,
-        };
-        it('It encrypts only the specified fields', () => {
-          return testCryptoClient
-            .encrypt(testKey, testData, encryptionOptions)
-            .then((encrypted) => {
-              expect(Object.keys(encrypted)).to.deep.equal(
-                Object.keys(testData)
-              );
-
-              Object.keys(encrypted).forEach((objectKey) => {
-                if (testFieldsToEncrypt.includes(objectKey)) {
-                  encryptedDataExpectations(encrypted[objectKey]);
-                  const { body } = dataHelpers.parseEncryptedData(
-                    encrypted[objectKey]
-                  );
-                  return expect(MockCageService.decrypt(body)).to.deep.equal(
-                    testData[objectKey]
-                  );
-                }
-                return expect(encrypted[objectKey]).to.deep.equal(
-                  testData[objectKey]
-                );
-              });
-            });
-        });
-      });
-    });
-  });
-
-  context('Encrypting buffer', () => {
-    const testKey = MockCageService.getMockCageKey();
-
-    const testData = Buffer.from('test data in a buffer', 'utf8');
-    it('Returns the buffer encrypted as a string', () => {
-      return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        encryptedDataExpectations(encrypted);
-        const { body } = dataHelpers.parseEncryptedData(encrypted);
-        const decrypted = MockCageService.decrypt(body);
-        expect(Buffer.from(decrypted)).to.deep.equal(testData);
       });
     });
   });
@@ -125,25 +84,9 @@ describe('Crypto Module', () => {
 
     it('Returns the data encrypted as a string and it decrypts to a number', () => {
       return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        encryptedDataExpectations(encrypted);
-        const { body } = dataHelpers.parseEncryptedData(encrypted);
-        expect(MockCageService.decrypt(body)).to.equal(testData);
-      });
-    });
-  });
-
-  context('Encrypting a function', () => {
-    const testData = function (x, y) {
-      return x + y;
-    };
-    const testKey = MockCageService.getMockCageKey();
-
-    it('Encrypts the function and decrypts it to a stringified function', () => {
-      return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        encryptedDataExpectations(encrypted);
-        const { body } = dataHelpers.parseEncryptedData(encrypted);
-        const decrypted = MockCageService.decrypt(body);
-        expect(decrypted).to.equal(testData.toString());
+        encryptedDataExpectations(encrypted, 'number');
+        const { header, body } = dataHelpers.parseEncryptedData(encrypted);
+        expect(MockCageService.decrypt(header, body)).to.equal(testData);
       });
     });
   });
@@ -154,9 +97,9 @@ describe('Crypto Module', () => {
 
     it('Encrypts the array and decrypts it to the input data', () => {
       return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        encryptedDataExpectations(encrypted);
-        const { body } = dataHelpers.parseEncryptedData(encrypted);
-        expect(MockCageService.decrypt(body)).to.deep.equal(testData);
+        encryptedDataExpectations(encrypted, 'Array');
+        const { header, body } = dataHelpers.parseEncryptedData(encrypted);
+        expect(MockCageService.decrypt(header, body)).to.deep.equal(testData);
       });
     });
   });
@@ -191,40 +134,36 @@ describe('Crypto Module', () => {
     };
     const testKey = MockCageService.getMockCageKey();
 
-    it('Encrypts the object including the null values', () => {
+    it('Encrypts the object but ignores null', () => {
       return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
         expect(Object.keys(encrypted)).to.deep.equal(Object.keys(testData));
 
-        Object.keys(encrypted).forEach((objectKey) => {
-          encryptedDataExpectations(encrypted[objectKey]);
-          const { body } = dataHelpers.parseEncryptedData(encrypted[objectKey]);
-          expect(MockCageService.decrypt(body)).to.deep.equal(
-            testData[objectKey]
+        const testEncryptedValue = (key, type) => {
+          encryptedDataExpectations(encrypted[key], type);
+          const { header, body } = dataHelpers.parseEncryptedData(
+            encrypted[key]
           );
-        });
+          expect(MockCageService.decrypt(header, body)).to.deep.equal(
+            testData[key]
+          );
+        };
+
+        testEncryptedValue('a', 'number');
+        testEncryptedValue('b', 'boolean');
+        expect(encrypted.c).to.deep.equal(testData.c);
       });
     });
   });
 
-  context('Encrypting an object with undefined and null values', () => {
-    const testData = {
-      a: 1,
-      b: null,
-      c: undefined,
-    };
+  context('Discards unencryptable data', () => {
     const testKey = MockCageService.getMockCageKey();
 
-    it('Encrypts the object including the null values, presists the undefined values', () => {
-      return testCryptoClient.encrypt(testKey, testData).then((encrypted) => {
-        ['a', 'b'].forEach((objectKey) => {
-          encryptedDataExpectations(encrypted[objectKey]);
-          const { body } = dataHelpers.parseEncryptedData(encrypted[objectKey]);
-          expect(MockCageService.decrypt(body)).to.deep.equal(
-            testData[objectKey]
-          );
+    it('Throws an error', () => {
+      return testCryptoClient
+        .encrypt(testKey, Buffer.from('abc123'))
+        .catch((err) => {
+          expect(err).to.match(/supplied isn't encryptable/);
         });
-        expect(encrypted.c).to.deep.equal(testData.c);
-      });
     });
   });
 });

--- a/tests/datatypes.test.js
+++ b/tests/datatypes.test.js
@@ -197,4 +197,36 @@ describe('Datatypes', () => {
       expect(decoded).to.equal(testString);
     });
   });
+
+  describe('isEncryptable', () => {
+    it('number is encryptable', () => {
+      expect(Datatypes.isEncryptable(1)).to.be.true;
+    });
+
+    it('undefined isnt encryptable', () => {
+      expect(Datatypes.isEncryptable(undefined)).to.be.false;
+    });
+
+    it('object isnt encryptable', () => {
+      expect(Datatypes.isEncryptable({})).to.be.false;
+    });
+  });
+
+  describe('getHeaderType', () => {
+    it('undefined objects return nothing', () => {
+      expect(Datatypes.getHeaderType(undefined)).to.be.undefined;
+    });
+
+    it('array returns "Array"', () => {
+      expect(Datatypes.getHeaderType([1, 2, 3])).to.equal('Array');
+    });
+
+    it('number returns "number"', () => {
+      expect(Datatypes.getHeaderType(1)).to.equal('number');
+    });
+
+    it('string returns "string"', () => {
+      expect(Datatypes.getHeaderType('test')).to.equal('string');
+    });
+  });
 });

--- a/tests/utilities/keyService.mock.js
+++ b/tests/utilities/keyService.mock.js
@@ -22,7 +22,7 @@ module.exports = () => {
     return keyPair.publicKey;
   };
 
-  const decrypt = (data) => {
+  const decrypt = (header, data) => {
     const parsedData = parseBase64ToJson(data);
 
     const encryptionKey = crypto.privateDecrypt(
@@ -54,6 +54,9 @@ module.exports = () => {
     );
     decrypted += decipher.final('utf8');
     try {
+      if (header.datatypes === 'number') {
+        return Number(decrypted);
+      }
       return JSON.parse(decrypted);
     } catch (e) {
       return decrypted;


### PR DESCRIPTION
# Why
We want to put the original datatype into the header of our encrypted strings. The datatype is then used to parse out the result
Also implemented object traversal. If you give an object, it will only encrypt primitives.

# How
Add it to the header and update types.