### PR TITLE
Add null check to isArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ dist
 .vscode/
 
 .debug
+
+# MAC
+*.DS_Store

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -1,4 +1,4 @@
-const isArray = (data) => data.constructor.name === 'Array';
+const isArray = (data) => isDefined(data) && data.constructor.name === 'Array';
 const isBuffer = (data) => data.constructor.name.toLowerCase() === 'buffer';
 const isObject = (data) => typeof data === 'object';
 const isObjectStrict = (data) =>

--- a/tests/datatypes.test.js
+++ b/tests/datatypes.test.js
@@ -14,6 +14,13 @@ describe('Datatypes', () => {
         expect(Datatypes.isArray(0)).to.be.false;
       });
     });
+
+    context('Data is null or undefined', () => {
+      it('returns false', () => {
+        expect(Datatypes.isArray(null)).to.be.false;
+        expect(Datatypes.isArray(undefined)).to.be.false;
+      });
+    })
   });
 
   describe('isObject', () => {


### PR DESCRIPTION
# Why
SDK explodes when parsing `null`.

# How
Add `isDefined` check on array traversal to stop this happening and add test for it.

# Error
```
(node:3565) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'constructor' of null
    at Object.isArray (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/utils/datatypes.js:1:32)
    at _traverseObject (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/core/crypto.js:36:26)
    at _traverseObject (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/core/crypto.js:33:38)
    at async _encryptObject (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/core/crypto.js:19:12)
    at async Object.encrypt (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/core/crypto.js:87:14)
    at async EvervaultClient.encrypt (/Users/eoinboylan/ev/snippets/ev-node-snippet/node_modules/@evervault/sdk/lib/index.js:98:12)
    at async encrypt (/Users/eoinboylan/ev/snippets/ev-node-snippet/index.js:10:10)
    at async /Users/eoinboylan/ev/snippets/ev-node-snippet/index.js:13:18
(node:3565) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:3565) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code
```