### PR TITLE
Remove cyclic dependency

### DIFF
--- a/lib/utils/deploy.js
+++ b/lib/utils/deploy.js
@@ -2,7 +2,6 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const errors = require('./errors');
-const { deploy } = require('.');
 
 const getPackagePath = () => path.resolve(process.cwd(), 'package.json');
 


### PR DESCRIPTION
# Why

Deploy file required itself, and looked for a function (`deploy`) which did not exist.

# How

Delete cyclic dependency