### PR TITLE
Add Action to deploy automatically with semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Test & release npm package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14.x"
+        - run: npm ci
+        - run: npm test
+        - run: npx semantic-release
+          env:
+            GH_TOKEN: ${{ secrets.GH_TOKEN }}
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "rewire": "^5.0.0",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0"
+  },
+  "release": {
+    "branches": [
+      "master"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/sdk",
-  "version": "1.2.5",
+  "version": "0.0.0",
   "description": "Node.js SDK for Evervault",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
# Why
To avoid having to manually run `npm publish` from authenticated machines.