### PR TITLE
Fix bug with path to rootCA.crt in Node SDK

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Config = require('./config');
 const { Crypto, Http, Labs } = require('./core');
 const HttpsProxyAgent = require('https-proxy-agent');
 const tls = require("tls");
+const { join } = require('path');
 
 
 const https = require('https');
@@ -57,7 +58,7 @@ class EvervaultClient {
       const context = origCreateSecureContext(options);
 
       const pem = require('fs')
-        .readFileSync("./lib/rootCA.crt", { encoding: "ascii" })
+        .readFileSync(join(__dirname, 'rootCA.crt'), { encoding: "ascii" })
 
       context.context.addCACert(pem.trim());
       return context;


### PR DESCRIPTION
# Why
Current path is not relative to the location of the node module so users will get a file not found error

# How
Make the path relative