### PR TITLE
Fix Evervault logo link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Evervault](https://evervault.com/evervault.svg)](https://welcome.evervault.com/)
+[![Evervault](https://evervault.com/evervault.svg)](https://evervault.com/)
 
 # Evervault Node.js SDK
 


### PR DESCRIPTION
Link was pointing to old welcome.evervault.com website.