### PR TITLE
Deirdre/eng 1050 add new encrypted string format to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For full installation support, [book time here](https://calendly.com/evervault/c
 
 ## Documentation
 
-See the Evervault [Node.js SDK documentation](https://docs.evervault.com/nodejs).
+See the Evervault [Node.js SDK documentation](https://docs.evervault.com/sdk/nodejs).
 
 ## Installation
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,7 @@ module.exports = (apikey) => ({
     keyLength: 32,
     ivLength: 12,
     authTagLength: 16,
+    evVersion: 'DUB',
     header: {
       iss: 'evervault',
       version: 1,

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -74,8 +74,10 @@ module.exports = (config) => {
     );
   };
 
+  const _evVersionPrefix = base64RemovePadding(Buffer.from(config.evVersion).toString('base64'));
+
   const _format = (datatype = 'string', keyIv, ecdhPublicKey, encryptedData) => {
-    return `ev${datatype !== 'string' ? ':' + datatype : ''}:${base64RemovePadding(keyIv)}:${base64RemovePadding(ecdhPublicKey)}:${base64RemovePadding(encryptedData)}:$`;
+    return `ev:${_evVersionPrefix}${datatype !== 'string' ? ':' + datatype : ''}:${base64RemovePadding(keyIv)}:${base64RemovePadding(ecdhPublicKey)}:${base64RemovePadding(encryptedData)}:$`;
   };
 
   const encrypt = async (ecdhPublicKey, derivedSecret, data, options = DEFAULT_ENCRYPT_OPTIONS) => {

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -1,41 +1,88 @@
 const { expect } = require('chai');
-const { createKeyServiceMock, dataHelpers } = require('../utilities');
-
-const MockCageService = createKeyServiceMock();
-const rewire = require('rewire');
-const Crypto = rewire('../../lib/core/crypto');
-const testingUuid = 'returned-uuid';
-Crypto.__set__({
-  uuid: () => testingUuid,
-});
+const crypto = require('crypto');
+const Crypto = require('../../lib/core/crypto');
 
 const testApiKey = 'test-api-key';
 const testConfig = require('../../lib/config')(testApiKey).encryption;
+const testEcdhCageKey = 'AjLUS3L3KagQud+/3R1TnGQ2XSF763wFO9cd/6XgaW86';
 
 
 describe('Crypto Module', () => {
   const testCryptoClient = Crypto(testConfig);
 
+  const ecdh = crypto.createECDH(testConfig.ecdhCurve);
+  ecdh.generateKeys();
+  const publicKey = ecdh.getPublicKey(null, 'compressed').toString('base64');
+  const derivedSecret = ecdh.computeSecret(Buffer.from(testEcdhCageKey, 'base64'));
+
   context('Encrypting object', () => {
-    const testKey = MockCageService.getMockCageKey();
     const testData = {
-      a: 1,
-      b: 'foo',
-      c: {
-        arr: [1, 2, 3, 4],
-      },
-    };
+      name: 'testname',
+      age: 20,
+      array: ['team1', 1],
+      dict: {
+          subname: 'subtestname',
+          subnumber: 2
+      }
+    }
+
+    it('Maintains JSON structure', () => {
+      return testCryptoClient.encrypt(publicKey, derivedSecret, testData).then((res) => {
+        expect('name' in res).to.be.true;
+        expect('dict' in res).to.be.true;
+        expect(typeof(res['dict']) === 'object' && res['dict'] !== null).to.be.true;
+        expect(isEvervaultString(res['dict']['subnumber'], 'number')).to.be.true;
+      })
+    });
+
+    it('Encrypts to Evervault string', () => {
+      return testCryptoClient.encrypt(publicKey, derivedSecret, testData).then((res) => {
+        recursiveIsEvervaultStringFormat(res);
+        expect(isEvervaultString(res['name'], 'string')).to.be.true;
+        expect(isEvervaultString(res['age'], 'number')).to.be.true;
+      })
+    });
   });
 
-
   context('Data is undefined', () => {
-    const testData = null;
-    const testKey = MockCageService.getMockCageKey();
-
     it('Throws an error', () => {
-      return testCryptoClient.encrypt(testKey, testData).catch((err) => {
+      return testCryptoClient.encrypt(publicKey, derivedSecret, null).catch((err) => {
         expect(err).to.match(/must not be undefined/);
       });
     });
   });
+
+  const recursiveIsEvervaultStringFormat = (data) => {
+    if(data !== null && typeof data == "object" ) {
+      Object.entries(data).forEach(([key, value]) => {
+        recursiveIsEvervaultStringFormat(value);
+      });
+    }
+    else {
+      expect(isEvervaultStringFormat(data)).to.be.true;
+    }
+  }
+
+  const isEvervaultString = (data, type) => {
+    parts = data.split(':');
+    if(!isEvervaultStringFormat(data)){
+      return false;
+    }
+    if(type != 'string' && type != parts[2]){
+      return false;
+    }
+    return true;
+  }
+
+  const isEvervaultStringFormat = (data) => {
+    parts = data.split(':');
+    if(parts.length < 6){
+      return false;
+    }
+    if(parts[2] == "number" || parts[2] == "boolean"){
+      return parts.length == 7;
+    }
+    return true;
+  }
+
 });


### PR DESCRIPTION
# Why
We need to handle the new encrypted string format as discussed in the Duplicate Data doc

# How
Added new version prefix to the string to match the following format:
ev:[version]:[datatype]:Base64(KeyIV):Base64(ECDHPublicKey):Base64(AESEncryptedData):$

Also introduced tests to cover encrypted string format