### PR TITLE
Default outbound Relay to ON in Node SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Evervault Node.js SDK
 
-The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Cages.
+The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted by Relay – and decrypted.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ evervault.cagify(cageName: String, cageFunction: Function);
 You may pass in an array of domains which you **don’t** want to be intercepted, i.e. requests sent to these domains will not be intercepted, and hence not decrypted. This array is passed in the `ignoreDomains` option.
 
 ```javascript
-const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.org', 'facebook.com'] });
-// Requests sent to https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
+const evervaultClient = new Evervault('<API-KEY>', {
+  ignoreDomains: ['httpbin.org', 'facebook.com'], // requests to these domains will not be sent thorough Relay
+});
 ```
 
 ### Disable interception on all requests

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You may pass in an array of domains which you **don’t** want to be intercepted
 
 ```javascript
 const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.org', 'facebook.com'] });
-// Requests sent to URLs such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
+// Requests sent to https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
 ```
 
 ### Disable interception on all requests

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ evervault.cagify(cageName: String, cageFunction: Function);
 
 ### Disable interception on requests to specific domains
 
-You may pass in an array of domains which you **don't** want to be intercepted by Relay, i.e. requests sent to these domains will not go through Relay, and hence will not be decrypted. This array is passed in the `ignoreDomains` option.
+You may pass in an array of domains which you **don’t** want to be intercepted, i.e. requests sent to these domains will not be intercepted, and hence not decrypted. This array is passed in the `ignoreDomains` option.
 
 ```javascript
 const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.org', 'facebook.com'] });

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Evervault Node.js SDK
 
-The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted by Relay – and decrypted.
+The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.or
 ```
 
 ### Disable Relay interception on all requests
-
-To disable all outbound requests being decrypted, you may set the `intercept` option to `false` when initializing the SDK. 
+To disable all outbound requests being decrypted, you may set the `intercept` option to `false` when initializing the SDK.
 
 ```javascript
 const evervault = new Evervault('<API-KEY>', { intercept: false });

--- a/README.md
+++ b/README.md
@@ -97,22 +97,21 @@ evervault.cagify(cageName: String, cageFunction: Function);
 | cageName | String | Name of the Cage to be run |
 | cageFunction | Function | The function to deploy as a Cage |
 
-### Outbound Relay
+### Disable Relay interception on requests to specfic domains
 
-You may configure the SDK to automatically route all outbound HTTPS requests through [Relay](https://docs.evervault.com/product/relay) by setting `relay` to `true` in the initialization options. Note: Cage runs will not be sent through Relay; your data will be decrypted as it enters the Cage.
+You may pass in an array of domains which you **don't** want to be intercepted by Relay, i.e. requests sent to these domains will not go through Relay, and hence will not be decrypted. This array is passed in the `ignoreDomains` option.
 
 ```javascript
-const evervaultClient = new Evervault('<API-KEY>', { relay: true });
+const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.org', 'facebook.com'] });
+// Requests sent to URLs such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
 ```
 
-You may also optionally pass in an array of domains which you **don't** want to go through Relay, i.e. requests sent to these domains will not be decrypted.
+### Disable Relay interception on all requests
+
+To disable all outbound requests being decrypted, you may set the `intercept` option to `false` when initializing the SDK. 
 
 ```javascript
-const evervaultClient = new Evervault(
-    '<API-KEY>',
-    { relay: true , ignoreDomains: ['httpbin.org', 'facebook.com'] }
-);
-// Requests sent to URLs such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
+const evervault = new Evervault('<API-KEY>', { intercept: false });
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const evervaultClient = new Evervault('<API-KEY>', { ignoreDomains: ['httpbin.or
 // Requests sent to URLs such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
 ```
 
-### Disable Relay interception on all requests
+### Disable interception on all requests
 To disable all outbound requests being decrypted, you may set the `intercept` option to `false` when initializing the SDK.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ evervault.cagify(cageName: String, cageFunction: Function);
 | cageName | String | Name of the Cage to be run |
 | cageFunction | Function | The function to deploy as a Cage |
 
-### Disable Relay interception on requests to specfic domains
+### Disable interception on requests to specific domains
 
 You may pass in an array of domains which you **don't** want to be intercepted by Relay, i.e. requests sent to these domains will not go through Relay, and hence will not be decrypted. This array is passed in the `ignoreDomains` option.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,10 +26,8 @@ class EvervaultClient {
       crypto.createECDH(this.config.encryption.ecdhCurve)
     );
 
-    if (options.relay) {
-      if (!options.disableTunnel) {
-        this._overloadHttpsModule(apiKey, this.config.http.tunnelHostname, options.ignoreDomains);
-      }
+    if (options.intercept === undefined || options.intercept === true) {
+      this._overloadHttpsModule(apiKey, this.config.http.tunnelHostname, options.ignoreDomains);
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class EvervaultClient {
       crypto.createECDH(this.config.encryption.ecdhCurve)
     );
 
-    if (options.intercept === undefined || options.intercept === true) {
+    if (options.intercept !== false) {
       this._overloadHttpsModule(apiKey, this.config.http.tunnelHostname, options.ignoreDomains);
     }
   }


### PR DESCRIPTION
# Why
Easier for users to integrate their API with Evervault. Just point Relay at the API, and initialize the SDK in the API.

# How
The user can set `{ intercept: false }` when initializing to turn it off.