### PR TITLE
Add Metrics to Encrypt Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const evervaultClient = new Evervault('<API-KEY>', {
 ```
 
 ### Disable interception on all requests
+
 To disable all outbound requests being decrypted, you may set the `intercept` option to `false` when initializing the SDK.
 
 ```javascript

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,11 +1,13 @@
 const { version } = require('../package.json');
 const API_URL = 'https://api.evervault.com';
 const CAGE_RUN_URL = 'https://run.evervault.com';
+const METRICS_URL = 'https://metrics.evervault.com';
 
 module.exports = (apikey) => ({
   http: {
     baseUrl: API_URL,
     cageRunUrl: CAGE_RUN_URL,
+    metricsUrl: METRICS_URL,
     headers: {
       'API-KEY': apikey,
       'user-agent': `evervault-node/${version}`

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -14,7 +14,7 @@ const DEFAULT_ENCRYPT_OPTIONS = {
   fieldsToEncrypt: undefined,
 };
 
-module.exports = (config) => {
+module.exports = (config, http) => {
   const _encryptObject = async (ecdhPublicKey, derivedSecret, data) => {
     return await _traverseObject(ecdhPublicKey, derivedSecret, { ...data });
   };
@@ -49,6 +49,8 @@ module.exports = (config) => {
   };
 
   const _encryptString = async (ecdhPublicKey, derivedSecret, str, datatype) => {
+    http.reportMetric()
+
     const keyIv = await generateBytes(config.ivLength);
 
     const cipher = crypto.createCipheriv(
@@ -59,7 +61,7 @@ module.exports = (config) => {
         authTagLength: config.authTagLength,
       }
     );
-    
+
     const encryptedBuffer = Buffer.concat([
       cipher.update(str, 'utf8'),
       cipher.final(),

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -49,7 +49,9 @@ module.exports = (config, http) => {
   };
 
   const _encryptString = async (ecdhPublicKey, derivedSecret, str, datatype) => {
-    http.reportMetric()
+    try {
+      http.reportMetric()
+    } catch (err) { }
 
     const keyIv = await generateBytes(config.ivLength);
 

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -42,10 +42,10 @@ module.exports = (config) => {
 
   const buildRunHeaders = ({ version, async }) => {
     const headers = {};
-    if(version){
+    if (version) {
       headers['x-version-id'] = version;
     }
-    if(async){
+    if (async) {
       headers['x-async'] = 'true';
     }
     return headers;
@@ -61,5 +61,11 @@ module.exports = (config) => {
     });
   }
 
-  return { getCageKey, runCage, getCert };
+  const reportMetric = () => {
+    try {
+      post(config.metricsUrl, '', { event: 'Data Encrypted' })
+    } catch (err) { }
+  }
+
+  return { getCageKey, runCage, getCert, reportMetric };
 };

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -62,9 +62,7 @@ module.exports = (config) => {
   }
 
   const reportMetric = () => {
-    try {
-      post(config.metricsUrl, '', { event: 'Data Encrypted' })
-    } catch (err) { }
+    return post(config.metricsUrl, '', { event: 'Data Encrypted' })
   }
 
   return { getCageKey, runCage, getCert, reportMetric };

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -62,7 +62,7 @@ module.exports = (config) => {
   }
 
   const reportMetric = () => {
-    return post(config.metricsUrl, '', { event: 'Data Encrypted' })
+    return post(config.metricsUrl, { event: 'Data Encrypted' })
   }
 
   return { getCageKey, runCage, getCert, reportMetric };

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ class EvervaultClient {
   async _overloadHttpsModule(apiKey, tunnelHostname, ignoreDomains = []) {
     let pem = await this.http.getCert();
 
+    ignoreDomains.push('metrics.evervault.com')
+
     const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
     const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ class EvervaultClient {
     let pem = await this.http.getCert();
 
     ignoreDomains.push('metrics.evervault.com')
+    ignoreDomains.push('ca.evervault.com')
 
     const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
     const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,8 @@ class EvervaultClient {
     }
 
     this.config = Config(apiKey);
-    this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http);
+    this.crypto = Crypto(this.config.encryption, this.http);
 
     this.defineHiddenProperty(
       '_ecdh',
@@ -41,7 +41,7 @@ class EvervaultClient {
     const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
     const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
 
-    const originalRequest = https.request; 
+    const originalRequest = https.request;
     https.request = function wrapMethodRequest(...args) {
       const ignore = isIgnoreRequest(args);
       args = args.map(arg => {
@@ -68,10 +68,10 @@ class EvervaultClient {
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {
-        let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
-        ignoreExact.push(exact);
-        ignoreEndsWith.push('.' + exact);
-        ignoreEndsWith.push('@' + exact);
+      let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
+      ignoreExact.push(exact);
+      ignoreEndsWith.push('.' + exact);
+      ignoreEndsWith.push('@' + exact);
     });
     return [ignoreExact, ignoreEndsWith];
   }
@@ -143,7 +143,7 @@ class EvervaultClient {
     }
     if (!Datatypes.isString(cageName))
       throw new errors.EvervaultError('Cage name invalid');
-    if(
+    if (
       Datatypes.isObjectStrict(options) &&
       Datatypes.isDefined(options.version) &&
       !Datatypes.isNumber(options.version)
@@ -170,32 +170,32 @@ class EvervaultClient {
 
     const { cageHash, functionRequires, functionParameters } = sourceParser.parseSource(func);
     if (cageLock.deployCheck(cageName, cageHash)) {
-        const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
-        cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
+      const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
+      cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
     }
 
     const cageVersion = cageLock.getLatestVersion(cageName);
 
     return async (...parameters) => {
-        const data = {};
-        parameters.forEach((param, index) => {
-            data[functionParameters[index]] = param;
-        })
+      const data = {};
+      parameters.forEach((param, index) => {
+        data[functionParameters[index]] = param;
+      })
 
-        const runtimeObject = {
-            environment: await this.encrypt(environment.getEnvironment(func)),
-            data
-        };
+      const runtimeObject = {
+        environment: await this.encrypt(environment.getEnvironment(func)),
+        data
+      };
 
-        const result = await this.run(cageName, runtimeObject, {
-          'x-cage-version': cageVersion
-        });
+      const result = await this.run(cageName, runtimeObject, {
+        'x-cage-version': cageVersion
+      });
 
-        if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
-        return result.result;
+      if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
+      return result.result;
     };
   }
- 
+
   /**
    * @param {String} cageName
    * @param {Object} data


### PR DESCRIPTION
# Why

Currently we have no way of knowing how many fields are getting encrypted using the Evervault

# How

Adds a call to the metrics endpoint with a `Data Encrypted` event. Also stops `metrics` and `ca` subdomains from going through Relay