### PR TITLE
Retry getting the CA if it fails once

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -32,6 +32,13 @@ module.exports = (config) => {
       url: certHost,
       method: 'GET',
       parse: 'cer',
+    }).catch(() => {
+      // Blindly retry
+      return phin({
+        url: certHost,
+        method: 'GET',
+        parse: 'cer'
+      })
     }).catch((err) => {
       throw new errors.CertError(
         `Unable to download cert from ${certHost} (${err.message})`
@@ -42,10 +49,10 @@ module.exports = (config) => {
 
   const buildRunHeaders = ({ version, async }) => {
     const headers = {};
-    if(version){
+    if (version) {
       headers['x-version-id'] = version;
     }
-    if(async){
+    if (async) {
       headers['x-async'] = 'true';
     }
     return headers;


### PR DESCRIPTION
# Why

Certain errors such as socket hangups can be retried client side.

# How

Approach for if it fails is just to try again, and only error if that doesn't work too