### PR TITLE
Fix SDK backwards compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class EvervaultClient {
       crypto.createECDH(this.config.encryption.ecdhCurve)
     );
 
-    if (options.intercept !== false) {
+    if (options.intercept !== false && options.relay !== false) {
       this._overloadHttpsModule(apiKey, this.config.http.tunnelHostname, options.ignoreDomains);
     }
   }


### PR DESCRIPTION
# Why

We previously changed the interface for disabling relay, but the change was not backwards compatible.

# How

Made sure that both `intercept !== false` and `relay !== false` holds before overriding the HTTP requests.