### PR TITLE
Fix race condition downloading cert

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,30 +36,46 @@ class EvervaultClient {
    * @returns {void}
    */
   async _overloadHttpsModule(apiKey, tunnelHostname, ignoreDomains = []) {
-    let pem = await this.http.getCert();
+    let pem;
 
-    const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
-    const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
+    const getCertPromise = this.http.getCert().then(cert => {
+      pem = cert;
+    });
 
-    const originalRequest = https.request; 
-    https.request = function wrapMethodRequest(...args) {
-      const ignore = isIgnoreRequest(args);
-      args = args.map(arg => {
-        if (!ignore && arg instanceof Object) {
-          arg.agent = new HttpsProxyAgent(tunnelHostname);
-          arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
-        }
-        return arg;
-      });
-      return originalRequest.apply(this, args);
+    const originalRequest = https.request;
+    https.request = funciton wrapRequest(..args) {
+      if (!pem && typeof getCertPromise === 'promise') {
+        // Race getCert vs short timeout
+        // makerequest
+      } else {
+        // makerequest
+      }
     }
 
-    const origCreateSecureContext = tls.createSecureContext;
-    tls.createSecureContext = (options) => {
-      const context = origCreateSecureContext(options);
-      context.context.addCACert(pem);
-      return context;
-    };
+    // let pem = await this.http.getCert();
+
+    // const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
+    // const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
+
+    // const originalRequest = https.request; 
+    // https.request = function wrapMethodRequest(...args) {
+    //   const ignore = isIgnoreRequest(args);
+    //   args = args.map(arg => {
+    //     if (!ignore && arg instanceof Object) {
+    //       arg.agent = new HttpsProxyAgent(tunnelHostname);
+    //       arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
+    //     }
+    //     return arg;
+    //   });
+    //   return originalRequest.apply(this, args);
+    // }
+
+    // const origCreateSecureContext = tls.createSecureContext;
+    // tls.createSecureContext = (options) => {
+    //   const context = origCreateSecureContext(options);
+    //   context.context.addCACert(pem);
+    //   return context;
+    // };
   }
 
   _parsedDomainsToIgnore(ignoreDomains) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,13 +39,13 @@ class EvervaultClient {
     let pem;
 
     const getCertPromise = this.http.getCert().then(cert => {
-      pem = cert;
+    pem = cert;
 
-      const origCreateSecureContext = tls.createSecureContext;
-      tls.createSecureContext = (options) => {
-        const context = origCreateSecureContext(options);
-        context.context.addCACert(pem);
-        return context;
+    const origCreateSecureContext = tls.createSecureContext;
+    tls.createSecureContext = (options) => {
+      const context = origCreateSecureContext(options);
+      context.context.addCACert(pem);
+      return context;
       };
     });
 
@@ -87,10 +87,10 @@ class EvervaultClient {
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {
-      let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
-      ignoreExact.push(exact);
-      ignoreEndsWith.push('.' + exact);
-      ignoreEndsWith.push('@' + exact);
+        let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
+        ignoreExact.push(exact);
+        ignoreEndsWith.push('.' + exact);
+        ignoreEndsWith.push('@' + exact);
     });
     return [ignoreExact, ignoreEndsWith];
   }
@@ -162,7 +162,7 @@ class EvervaultClient {
     }
     if (!Datatypes.isString(cageName))
       throw new errors.EvervaultError('Cage name invalid');
-    if (
+    if(
       Datatypes.isObjectStrict(options) &&
       Datatypes.isDefined(options.version) &&
       !Datatypes.isNumber(options.version)
@@ -189,32 +189,32 @@ class EvervaultClient {
 
     const { cageHash, functionRequires, functionParameters } = sourceParser.parseSource(func);
     if (cageLock.deployCheck(cageName, cageHash)) {
-      const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
-      cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
+        const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
+        cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
     }
 
     const cageVersion = cageLock.getLatestVersion(cageName);
 
     return async (...parameters) => {
-      const data = {};
-      parameters.forEach((param, index) => {
-        data[functionParameters[index]] = param;
-      })
+        const data = {};
+        parameters.forEach((param, index) => {
+            data[functionParameters[index]] = param;
+        })
 
-      const runtimeObject = {
-        environment: await this.encrypt(environment.getEnvironment(func)),
-        data
-      };
+        const runtimeObject = {
+            environment: await this.encrypt(environment.getEnvironment(func)),
+            data
+        };
 
-      const result = await this.run(cageName, runtimeObject, {
-        'x-cage-version': cageVersion
-      });
+        const result = await this.run(cageName, runtimeObject, {
+          'x-cage-version': cageVersion
+        });
 
-      if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
-      return result.result;
+        if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
+        return result.result;
     };
   }
-
+ 
   /**
    * @param {String} cageName
    * @param {Object} data

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,14 +38,14 @@ class EvervaultClient {
   async _overloadHttpsModule(apiKey, tunnelHostname, ignoreDomains = []) {
     let pem;
 
-    const getCertPromise = this.http.getCert().then(cert => {
-    pem = cert;
+    this.http.getCert().then(cert => {
+      pem = cert;
 
-    const origCreateSecureContext = tls.createSecureContext;
-    tls.createSecureContext = (options) => {
-      const context = origCreateSecureContext(options);
-      context.context.addCACert(pem);
-      return context;
+      const origCreateSecureContext = tls.createSecureContext;
+      tls.createSecureContext = (options) => {
+        const context = origCreateSecureContext(options);
+        context.context.addCACert(pem);
+        return context;
       };
     });
 
@@ -69,7 +69,7 @@ class EvervaultClient {
     https.request = function (...args) {
       if (isIgnoreRequest(args)) return originalRequest.apply(this, args);
 
-      if (!pem && typeof getCertPromise === 'promise' && attempts < 3) {
+      if (!pem && attempts < 3) {
         // Race getting the cert vs a 350ms timer
         const now = (new Date()).getTime()
         while (!pem && ((new Date()).getTime() - now) <= 350) { }

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,42 +40,43 @@ class EvervaultClient {
 
     const getCertPromise = this.http.getCert().then(cert => {
       pem = cert;
+
+      const origCreateSecureContext = tls.createSecureContext;
+      tls.createSecureContext = (options) => {
+        const context = origCreateSecureContext(options);
+        context.context.addCACert(pem);
+        return context;
+      };
     });
 
+    const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
+    const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
+
     const originalRequest = https.request;
-    https.request = funciton wrapRequest(..args) {
-      if (!pem && typeof getCertPromise === 'promise') {
-        // Race getCert vs short timeout
-        // makerequest
-      } else {
-        // makerequest
-      }
+
+    function wrappedRequest(...args) {
+      args = args.map(arg => {
+        if (arg instanceof Object) {
+          arg.agent = new HttpsProxyAgent(tunnelHostname);
+          arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
+        }
+        return arg;
+      });
+      return originalRequest.apply(this, args);
     }
 
-    // let pem = await this.http.getCert();
+    https.request = function (...args) {
+      if (isIgnoreRequest(args)) return originalRequest.apply(this, args);
 
-    // const [ignoreExact, ignoreEndsWith] = this._parsedDomainsToIgnore(ignoreDomains);
-    // const isIgnoreRequest = (domain) => this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
+      if (!pem && typeof getCertPromise === 'promise') {
+        // Race getting the cert vs a 350ms timer
+        const now = (new Date()).getTime()
+        while (!pem && ((new Date()).getTime() - now) <= 350) { }
+      }
 
-    // const originalRequest = https.request; 
-    // https.request = function wrapMethodRequest(...args) {
-    //   const ignore = isIgnoreRequest(args);
-    //   args = args.map(arg => {
-    //     if (!ignore && arg instanceof Object) {
-    //       arg.agent = new HttpsProxyAgent(tunnelHostname);
-    //       arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
-    //     }
-    //     return arg;
-    //   });
-    //   return originalRequest.apply(this, args);
-    // }
+      return wrappedRequest(...args)
+    }
 
-    // const origCreateSecureContext = tls.createSecureContext;
-    // tls.createSecureContext = (options) => {
-    //   const context = origCreateSecureContext(options);
-    //   context.context.addCACert(pem);
-    //   return context;
-    // };
   }
 
   _parsedDomainsToIgnore(ignoreDomains) {
@@ -84,10 +85,10 @@ class EvervaultClient {
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {
-        let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
-        ignoreExact.push(exact);
-        ignoreEndsWith.push('.' + exact);
-        ignoreEndsWith.push('@' + exact);
+      let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
+      ignoreExact.push(exact);
+      ignoreEndsWith.push('.' + exact);
+      ignoreEndsWith.push('@' + exact);
     });
     return [ignoreExact, ignoreEndsWith];
   }
@@ -159,7 +160,7 @@ class EvervaultClient {
     }
     if (!Datatypes.isString(cageName))
       throw new errors.EvervaultError('Cage name invalid');
-    if(
+    if (
       Datatypes.isObjectStrict(options) &&
       Datatypes.isDefined(options.version) &&
       !Datatypes.isNumber(options.version)
@@ -186,32 +187,32 @@ class EvervaultClient {
 
     const { cageHash, functionRequires, functionParameters } = sourceParser.parseSource(func);
     if (cageLock.deployCheck(cageName, cageHash)) {
-        const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
-        cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
+      const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
+      cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
     }
 
     const cageVersion = cageLock.getLatestVersion(cageName);
 
     return async (...parameters) => {
-        const data = {};
-        parameters.forEach((param, index) => {
-            data[functionParameters[index]] = param;
-        })
+      const data = {};
+      parameters.forEach((param, index) => {
+        data[functionParameters[index]] = param;
+      })
 
-        const runtimeObject = {
-            environment: await this.encrypt(environment.getEnvironment(func)),
-            data
-        };
+      const runtimeObject = {
+        environment: await this.encrypt(environment.getEnvironment(func)),
+        data
+      };
 
-        const result = await this.run(cageName, runtimeObject, {
-          'x-cage-version': cageVersion
-        });
+      const result = await this.run(cageName, runtimeObject, {
+        'x-cage-version': cageVersion
+      });
 
-        if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
-        return result.result;
+      if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
+      return result.result;
     };
   }
- 
+
   /**
    * @param {String} cageName
    * @param {Object} data

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,13 +65,15 @@ class EvervaultClient {
       return originalRequest.apply(this, args);
     }
 
+    let attempts = 0
     https.request = function (...args) {
       if (isIgnoreRequest(args)) return originalRequest.apply(this, args);
 
-      if (!pem && typeof getCertPromise === 'promise') {
+      if (!pem && typeof getCertPromise === 'promise' && attempts < 3) {
         // Race getting the cert vs a 350ms timer
         const now = (new Date()).getTime()
         while (!pem && ((new Date()).getTime() - now) <= 350) { }
+        attempts += 1
       }
 
       return wrappedRequest(...args)

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ class EvervaultClient {
   async _overloadHttpsModule(apiKey, tunnelHostname, ignoreDomains = []) {
     let pem;
 
-    this.http.getCert().then(cert => {
+    const getCertPromise = this.http.getCert().then(cert => {
       pem = cert;
 
       const origCreateSecureContext = tls.createSecureContext;
@@ -69,7 +69,7 @@ class EvervaultClient {
     https.request = function (...args) {
       if (isIgnoreRequest(args)) return originalRequest.apply(this, args);
 
-      if (!pem && attempts < 3) {
+      if (!pem && getCertPromise instanceof Promise && attempts < 3) {
         // Race getting the cert vs a 350ms timer
         const now = (new Date()).getTime()
         while (!pem && ((new Date()).getTime() - now) <= 350) { }
@@ -87,10 +87,10 @@ class EvervaultClient {
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {
-        let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
-        ignoreExact.push(exact);
-        ignoreEndsWith.push('.' + exact);
-        ignoreEndsWith.push('@' + exact);
+      let exact = domain.startsWith('www.') ? domain.slice(4) : domain;
+      ignoreExact.push(exact);
+      ignoreEndsWith.push('.' + exact);
+      ignoreEndsWith.push('@' + exact);
     });
     return [ignoreExact, ignoreEndsWith];
   }
@@ -162,7 +162,7 @@ class EvervaultClient {
     }
     if (!Datatypes.isString(cageName))
       throw new errors.EvervaultError('Cage name invalid');
-    if(
+    if (
       Datatypes.isObjectStrict(options) &&
       Datatypes.isDefined(options.version) &&
       !Datatypes.isNumber(options.version)
@@ -189,32 +189,32 @@ class EvervaultClient {
 
     const { cageHash, functionRequires, functionParameters } = sourceParser.parseSource(func);
     if (cageLock.deployCheck(cageName, cageHash)) {
-        const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
-        cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
+      const { deployedBy, deployedTeam, deployedVersion } = deploy.runDeployment(cageName, func, functionParameters, functionRequires);
+      cageLock.addCageToLockfile(cageName, cageHash, deployedBy, deployedTeam, deployedVersion);
     }
 
     const cageVersion = cageLock.getLatestVersion(cageName);
 
     return async (...parameters) => {
-        const data = {};
-        parameters.forEach((param, index) => {
-            data[functionParameters[index]] = param;
-        })
+      const data = {};
+      parameters.forEach((param, index) => {
+        data[functionParameters[index]] = param;
+      })
 
-        const runtimeObject = {
-            environment: await this.encrypt(environment.getEnvironment(func)),
-            data
-        };
+      const runtimeObject = {
+        environment: await this.encrypt(environment.getEnvironment(func)),
+        data
+      };
 
-        const result = await this.run(cageName, runtimeObject, {
-          'x-cage-version': cageVersion
-        });
+      const result = await this.run(cageName, runtimeObject, {
+        'x-cage-version': cageVersion
+      });
 
-        if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
-        return result.result;
+      if (result.statusCode === 404 || result.statusCode === 401) throw new errors.EvervaultError('API key mismatch: please ensure you have switched to your app\'s team in the CLI');
+      return result.result;
     };
   }
- 
+
   /**
    * @param {String} cageName
    * @param {Object} data


### PR DESCRIPTION
## Why

Previously, requests would not get decrypted on outbound because the request was being send before the CA was fetched.

## How

* If the cert is not present, race requests again a timeout of 350ms
* Do this a maximum of 3 times, so that every request does not induce latency for the user