### PR TITLE
Add semantic-release info to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,3 +4,9 @@ Add links to issues, tech plans etc.
 
 # How
 Describe how you've approached the problem
+
+### Commit Messages
+
+We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.
+
+Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.


### PR DESCRIPTION
# Why
Ensure people have access to the semantic-release documentation and commit messages are in the correct format

# How
Add to PR template