### PR TITLE
fix(relay): CA request shouldn't go through Relay

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,10 @@ class EvervaultClient {
 
   _parsedDomainsToIgnore(ignoreDomains) {
     const cagesHost = new URL(this.config.http.cageRunUrl).host;
+    const caHost = new URL(this.config.http.certHostname).host;
+
     ignoreDomains.push(cagesHost);
+    ignoreDomains.push(caHost);
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {


### PR DESCRIPTION
# Why

CA requests shouldn't be going through relay

# How

Added the CA to the ignore domains list