### PR TITLE
Fix Typo in Cert Fetching Retry Code

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -43,7 +43,7 @@ module.exports = (config) => {
       })
       .catch((err) => {
         throw new errors.CertError(
-          `Unable to download cert from ${certHost} (${err.message})`
+          `Unable to download cert from ${config.certHostname} (${err.message})`
         );
       });
     return response.body;

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -36,7 +36,7 @@ module.exports = (config) => {
       .catch(() => {
         // Blindly retry
         return phin({
-          url: cert.certHostname,
+          url: config.certHostname,
           method: 'GET',
           parse: 'cer',
         });


### PR DESCRIPTION
# Why

There was a typo

# How

Removed the typo 