### PR TITLE
Add Encrypt Metrics Reporting

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -14,7 +14,7 @@ const DEFAULT_ENCRYPT_OPTIONS = {
   fieldsToEncrypt: undefined,
 };
 
-module.exports = (config) => {
+module.exports = (config, http) => {
   const _encryptObject = async (ecdhPublicKey, derivedSecret, data) => {
     return await _traverseObject(ecdhPublicKey, derivedSecret, { ...data });
   };
@@ -62,6 +62,12 @@ module.exports = (config) => {
     str,
     datatype
   ) => {
+    try {
+      http.reportMetric();
+    } catch (err) {
+      // Ignore errors so they don't affect end users
+    }
+
     const keyIv = await generateBytes(config.ivLength);
 
     const cipher = crypto.createCipheriv(

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -74,5 +74,33 @@ module.exports = (config) => {
     );
   };
 
-  return { getCageKey, runCage, getCert };
+  const postMetric = async (count) => {
+    const metricsUrl = `metrics/sdkEncryptions?sdk=node&numEncryptions=${count}`;
+    try {
+      await post(metricsUrl);
+    } catch (e) {
+      // Ignore errors so they don't affect end users
+    }
+  };
+
+  let metricsCounter = 0;
+
+  const batchReportMetrics = () => {
+    if (metricsCounter > 0) {
+      const count = metricsCounter;
+      metricsCounter = 0;
+
+      postMetric(count);
+    }
+  };
+
+  setInterval(batchReportMetrics, 1500).unref();
+
+  process.on('beforeExit', batchReportMetrics);
+
+  const reportMetric = () => {
+    metricsCounter += 1;
+  };
+
+  return { getCageKey, runCage, getCert, reportMetric };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,8 @@ class EvervaultClient {
     }
 
     this.config = Config(apiKey);
-    this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http);
+    this.crypto = Crypto(this.config.encryption, this.http);
 
     this.defineHiddenProperty(
       '_ecdh',
@@ -87,9 +87,12 @@ class EvervaultClient {
   _parsedDomainsToIgnore(ignoreDomains) {
     const cagesHost = new URL(this.config.http.cageRunUrl).host;
     const caHost = new URL(this.config.http.certHostname).host;
+    const apiHost = new URL(this.config.http.baseUrl).host;
 
     ignoreDomains.push(cagesHost);
     ignoreDomains.push(caHost);
+    ignoreDomains.push(apiHost);
+
     let ignoreExact = [];
     let ignoreEndsWith = [];
     ignoreDomains.forEach((domain) => {


### PR DESCRIPTION
# Why

To better support our SDK development, we need to have some insight on how the SDKs are getting used.

# How

This PR adds a non-blocking metrics reporter (runs asynchronously). This will batch encrypt metric notifications and run periodically. If the application is going to exit and some metrics have still not been reported, then that is done.
