### PR TITLE
fix(relay): Typo for string type in _isIgnoreRequest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,7 @@ class EvervaultClient {
         ignore =
           this._exactOrEndsWith(arg.hostname, ignoreExact, ignoreEndsWith) ||
           this._exactOrEndsWith(arg.host, ignoreExact, ignoreEndsWith);
-      } else if (arg instanceof string)
+      } else if (arg instanceof String)
         ignore = this._exactOrEndsWith(arg, ignoreExact, ignoreEndsWith);
 
       if (ignore) return true;


### PR DESCRIPTION
# Why

We were checking for `instanceof string`, which should be `instanceof String`

# How

Fix typo

### Commit Messages

We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.

Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
