### PR TITLE
Add a checklist for commit message formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,6 @@ Add links to issues, tech plans etc.
 
 Describe how you've approached the problem
 
-### Commit Messages
+# Checklist
 
-We use [semantic-release](https://github.com/semantic-release/semantic-release#how-does-it-work) for deployments. If one of your commits should be deployed, ensure the commit message is in the format corresponding to the correct release type. This can also be done in a squash commit.
-
-Note: breaking changes should always use the `BREAKING CHANGE:` commit message format.
+- [ ] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked


### PR DESCRIPTION
# Why

For semantic release to work and for change-logs to be generated correctly for our users, commits must be formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/). While there is a git hook to enforce this, for quick fixes it might be forgotten.

# How

Added a checklist to the PR template

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
