### PR TITLE
feat: add option for p256 curve while defaulting to secp256k1 curve

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -31,7 +31,7 @@ module.exports = (apikey) => ({
         version: 1,
       },
     },
-    secp256r1: {
+    prime256v1: {
       ecdhCurve: 'prime256v1',
       keyCycleMinutes: 0.25,
       cipherAlgorithm: 'aes-256-gcm',

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,16 +18,31 @@ module.exports = (apikey) => ({
     certHostname: process.env.EV_CERT_HOSTNAME || DEFAULT_CA_HOSTNAME,
   },
   encryption: {
-    ecdhCurve: 'secp256k1',
-    keyCycleMinutes: 0.25,
-    cipherAlgorithm: 'aes-256-gcm',
-    keyLength: 32,
-    ivLength: 12,
-    authTagLength: 16,
-    evVersion: 'DUB',
-    header: {
-      iss: 'evervault',
-      version: 1,
+    secp256k1: {
+      ecdhCurve: 'secp256k1',
+      keyCycleMinutes: 0.25,
+      cipherAlgorithm: 'aes-256-gcm',
+      keyLength: 32,
+      ivLength: 12,
+      authTagLength: 16,
+      evVersion: 'DUB',
+      header: {
+        iss: 'evervault',
+        version: 1,
+      },
+    },
+    secp256r1: {
+      ecdhCurve: 'prime256v1',
+      keyCycleMinutes: 0.25,
+      cipherAlgorithm: 'aes-256-gcm',
+      keyLength: 32,
+      ivLength: 12,
+      authTagLength: 16,
+      evVersion: 'ORK',
+      header: {
+        iss: 'evervault',
+        version: 2,
+      },
     },
   },
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,15 +30,22 @@ class EvervaultClient {
         Buffer.from(apiKey.slice(3), 'base64')
       );
     }
+    let curve;
+    if (!options.curve || !this.config.encryption[options.curve]) {
+      curve = 'secp256k1'; //default to old curve
+    } else {
+      curve = options.curve;
+    }
 
     this.config = Config(apiKey);
+    this.curve = curve;
     this.retry = options.retry;
     this.http = Http(this.config.http);
-    this.crypto = Crypto(this.config.encryption, this.http);
+    this.crypto = Crypto(this.config.encryption[curve], this.http);
 
     this.defineHiddenProperty(
       '_ecdh',
-      crypto.createECDH(this.config.encryption.ecdhCurve)
+      crypto.createECDH(this.config.encryption[curve].ecdhCurve)
     );
 
     if (options.intercept !== false && options.relay !== false) {
@@ -162,7 +169,7 @@ class EvervaultClient {
           (ref) => {
             ref._refreshKeys();
           },
-          this.config.encryption.keyCycleMinutes * 60 * 1000,
+          this.config.encryption[this.curve].keyCycleMinutes * 60 * 1000,
           this
         ).unref()
       );

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,11 @@ const origCreateSecureContext = tls.createSecureContext;
 const originalRequest = https.request;
 
 class EvervaultClient {
+  static CURVES = {
+    SECP256K1: 'secp256k1',
+    PRIME256V1: 'prime256v1',
+  };
+
   constructor(apiKey, options = {}) {
     if (!Datatypes.isString(apiKey)) {
       throw new errors.InitializationError('API key must be a string');
@@ -30,9 +35,10 @@ class EvervaultClient {
         Buffer.from(apiKey.slice(3), 'base64')
       );
     }
+
     let curve;
     if (!options.curve || !this.config.encryption[options.curve]) {
-      curve = 'secp256k1'; //default to old curve
+      curve = EvervaultClient.CURVES.SECP256K1; //default to old curve
     } else {
       curve = options.curve;
     }

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -3,13 +3,104 @@ const crypto = require('crypto');
 const Crypto = require('../../lib/core/crypto');
 
 const testApiKey = 'test-api-key';
-const testConfig = require('../../lib/config')(testApiKey).encryption;
+const testConfigSecP256k1 =
+  require('../../lib/config')(testApiKey).encryption.secp256k1;
+const testConfigSecP256r1 =
+  require('../../lib/config')(testApiKey).encryption.secp256r1;
 const testEcdhCageKey = 'AjLUS3L3KagQud+/3R1TnGQ2XSF763wFO9cd/6XgaW86';
 
 describe('Crypto Module', () => {
-  const testCryptoClient = Crypto(testConfig);
+  const testCryptoClient = Crypto(testConfigSecP256k1);
 
-  const ecdh = crypto.createECDH(testConfig.ecdhCurve);
+  const ecdh = crypto.createECDH(testConfigSecP256k1.ecdhCurve);
+  ecdh.generateKeys();
+  const publicKey = ecdh.getPublicKey(null, 'compressed').toString('base64');
+  const derivedSecret = ecdh.computeSecret(
+    Buffer.from(testEcdhCageKey, 'base64')
+  );
+
+  context('Encrypting object', () => {
+    const testData = {
+      name: 'testname',
+      age: 20,
+      array: ['team1', 1],
+      dict: {
+        subname: 'subtestname',
+        subnumber: 2,
+      },
+    };
+
+    it('Maintains JSON structure', () => {
+      return testCryptoClient
+        .encrypt(publicKey, derivedSecret, testData)
+        .then((res) => {
+          expect('name' in res).to.be.true;
+          expect('dict' in res).to.be.true;
+          expect(typeof res['dict'] === 'object' && res['dict'] !== null).to.be
+            .true;
+          expect(isEvervaultString(res['dict']['subnumber'], 'number')).to.be
+            .true;
+        });
+    });
+
+    it('Encrypts to Evervault string', () => {
+      return testCryptoClient
+        .encrypt(publicKey, derivedSecret, testData)
+        .then((res) => {
+          recursiveIsEvervaultStringFormat(res);
+          expect(isEvervaultString(res['name'], 'string')).to.be.true;
+          expect(isEvervaultString(res['age'], 'number')).to.be.true;
+        });
+    });
+  });
+
+  context('Data is undefined', () => {
+    it('Throws an error', () => {
+      return testCryptoClient
+        .encrypt(publicKey, derivedSecret, null)
+        .catch((err) => {
+          expect(err).to.match(/must not be undefined/);
+        });
+    });
+  });
+
+  const recursiveIsEvervaultStringFormat = (data) => {
+    if (data !== null && typeof data == 'object') {
+      Object.entries(data).forEach(([key, value]) => {
+        recursiveIsEvervaultStringFormat(value);
+      });
+    } else {
+      expect(isEvervaultStringFormat(data)).to.be.true;
+    }
+  };
+
+  const isEvervaultString = (data, type) => {
+    parts = data.split(':');
+    if (!isEvervaultStringFormat(data)) {
+      return false;
+    }
+    if (type != 'string' && type != parts[2]) {
+      return false;
+    }
+    return true;
+  };
+
+  const isEvervaultStringFormat = (data) => {
+    parts = data.split(':');
+    if (parts.length < 6) {
+      return false;
+    }
+    if (parts[2] == 'number' || parts[2] == 'boolean') {
+      return parts.length == 7;
+    }
+    return true;
+  };
+});
+
+describe('Crypto Module with P256 Curve', () => {
+  const testCryptoClient = Crypto(testConfigSecP256r1);
+
+  const ecdh = crypto.createECDH(testConfigSecP256r1.ecdhCurve);
   ecdh.generateKeys();
   const publicKey = ecdh.getPublicKey(null, 'compressed').toString('base64');
   const derivedSecret = ecdh.computeSecret(

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -6,7 +6,7 @@ const testApiKey = 'test-api-key';
 const testConfigSecP256k1 =
   require('../../lib/config')(testApiKey).encryption.secp256k1;
 const testConfigSecP256r1 =
-  require('../../lib/config')(testApiKey).encryption.secp256r1;
+  require('../../lib/config')(testApiKey).encryption.prime256v1;
 const testEcdhCageKey = 'AjLUS3L3KagQud+/3R1TnGQ2XSF763wFO9cd/6XgaW86';
 
 describe('Crypto Module', () => {


### PR DESCRIPTION
# Why

- Allow users to add a `curve` to client configuration options. Default to `secp256k1` if no curve is provided for backwards compatibility. 
- We will need to send a note (in whatever form) to customers to let them know we're moving to a new curve in the future

# How

Describe how you've approached the problem

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
