### PR TITLE
Add DecryptError and ForbiddenIPError to JS SDK

### DIFF
--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -17,8 +17,18 @@ class RequestError extends EvervaultError {}
 
 class CertError extends EvervaultError {}
 
-const mapApiResponseToError = ({ statusCode, body }) => {
+class ForbiddenIPError extends EvervaultError {}
+
+class DecryptError extends EvervaultError {}
+
+const mapApiResponseToError = ({ statusCode, body, headers }) => {
   if (statusCode === 401) return new ApiKeyError('Invalid Api Key provided.');
+  if (statusCode === 403 && headers['x-evervault-error-code'] === 'forbidden-ip-error') {
+    return new ForbiddenIPError(body.message || 'IP is not present on the invoked Cage\'s whitelist.');
+  }
+  if (statusCode === 422) {
+    return new DecryptError(body.message || 'Unable to decrypt data.');
+  }
   if (statusCode === 423)
     return new AccountError(
       body.message ||
@@ -41,4 +51,6 @@ module.exports = {
   mapApiResponseToError,
   RequestError,
   CertError,
+  DecryptError,
+  ForbiddenIPError
 };

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -23,8 +23,13 @@ class DecryptError extends EvervaultError {}
 
 const mapApiResponseToError = ({ statusCode, body, headers }) => {
   if (statusCode === 401) return new ApiKeyError('Invalid Api Key provided.');
-  if (statusCode === 403 && headers['x-evervault-error-code'] === 'forbidden-ip-error') {
-    return new ForbiddenIPError(body.message || 'IP is not present on the invoked Cage\'s whitelist.');
+  if (
+    statusCode === 403 &&
+    headers['x-evervault-error-code'] === 'forbidden-ip-error'
+  ) {
+    return new ForbiddenIPError(
+      body.message || "IP is not present on the invoked Cage's whitelist."
+    );
   }
   if (statusCode === 422) {
     return new DecryptError(body.message || 'Unable to decrypt data.');
@@ -52,5 +57,5 @@ module.exports = {
   RequestError,
   CertError,
   DecryptError,
-  ForbiddenIPError
+  ForbiddenIPError,
 };

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "lint-staged": {
-    "**/*": "prettier --write --ignore-unknown ."
+    "**/*.js": "prettier --write --ignore-unknown \"./**/*.js\""
   },
   "config": {
     "commitizen": {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 
 const rewire = require('rewire');
 const { errors } = require('../lib/utils');
+const { ForbiddenIPError, DecryptError } = require('../lib/utils/errors')
 
 const cageName = 'test-cage',
   testData = { a: 1 };
@@ -172,6 +173,51 @@ describe('Testing the Evervault SDK', () => {
               expect(result).to.deep.equal({ result: testRunResult });
               expect(runNock.isDone()).to.be.true;
             });
+        });
+      });
+
+      context('Cage run receiving 403', () => {
+        beforeEach(() => {
+          runNock = nock(sdk.config.http.cageRunUrl, {
+            reqheaders: {
+              ...sdk.config.http.headers,
+            },
+          })
+          .post(`/${cageName}`)
+          .reply(403, { error: 'forbidden address'  }, { 'x-evervault-error-code': 'forbidden-ip-error' });
+        });
+
+        it('Calls the cage run api and throws a forbidden ip error', () => {
+          return sdk
+          .run(cageName, testData)
+          .catch((err) => {
+            expect(runNock.isDone()).to.be.true;
+            expect(err).to.be.instanceOf(ForbiddenIPError);
+          });
+        });
+      });
+
+      context('Cage run receiving 422', () => {
+        beforeEach(() => {
+          testRunResult = {
+            status: 'queued',
+          };
+          runNock = nock(sdk.config.http.cageRunUrl, {
+            reqheaders: {
+              ...sdk.config.http.headers,
+            },
+          })
+          .post(`/${cageName}`)
+          .reply(422, { error: 'decrypt failed' } );
+        });
+
+        it('Calls the cage run api and throws a decrypt failed error', () => {
+          return sdk
+          .run(cageName, testData, { async: true, version: 3 })
+          .catch((err) => {
+            expect(runNock.isDone()).to.be.true;
+            expect(err).to.be.instanceOf(DecryptError);
+          });
         });
       });
     });

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 
 const rewire = require('rewire');
 const { errors } = require('../lib/utils');
-const { ForbiddenIPError, DecryptError } = require('../lib/utils/errors')
+const { ForbiddenIPError, DecryptError } = require('../lib/utils/errors');
 
 const cageName = 'test-cage',
   testData = { a: 1 };
@@ -183,14 +183,16 @@ describe('Testing the Evervault SDK', () => {
               ...sdk.config.http.headers,
             },
           })
-          .post(`/${cageName}`)
-          .reply(403, { error: 'forbidden address'  }, { 'x-evervault-error-code': 'forbidden-ip-error' });
+            .post(`/${cageName}`)
+            .reply(
+              403,
+              { error: 'forbidden address' },
+              { 'x-evervault-error-code': 'forbidden-ip-error' }
+            );
         });
 
         it('Calls the cage run api and throws a forbidden ip error', () => {
-          return sdk
-          .run(cageName, testData)
-          .catch((err) => {
+          return sdk.run(cageName, testData).catch((err) => {
             expect(runNock.isDone()).to.be.true;
             expect(err).to.be.instanceOf(ForbiddenIPError);
           });
@@ -207,17 +209,17 @@ describe('Testing the Evervault SDK', () => {
               ...sdk.config.http.headers,
             },
           })
-          .post(`/${cageName}`)
-          .reply(422, { error: 'decrypt failed' } );
+            .post(`/${cageName}`)
+            .reply(422, { error: 'decrypt failed' });
         });
 
         it('Calls the cage run api and throws a decrypt failed error', () => {
           return sdk
-          .run(cageName, testData, { async: true, version: 3 })
-          .catch((err) => {
-            expect(runNock.isDone()).to.be.true;
-            expect(err).to.be.instanceOf(DecryptError);
-          });
+            .run(cageName, testData, { async: true, version: 3 })
+            .catch((err) => {
+              expect(runNock.isDone()).to.be.true;
+              expect(err).to.be.instanceOf(DecryptError);
+            });
         });
       });
     });


### PR DESCRIPTION
# Why

With the rollout of new error types from the Cage run API, need to reflect the errors in the SDKs.

# How

If the error matches one of our known types (DecryptError or ForbiddenIPError) then surface that error.

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
