### PR TITLE
fix: reorder constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,8 @@ class EvervaultClient {
       );
     }
 
+    this.config = Config(apiKey);
+
     let curve;
     if (!options.curve || !this.config.encryption[options.curve]) {
       curve = EvervaultClient.CURVES.SECP256K1; //default to old curve
@@ -43,7 +45,6 @@ class EvervaultClient {
       curve = options.curve;
     }
 
-    this.config = Config(apiKey);
     this.curve = curve;
     this.retry = options.retry;
     this.http = Http(this.config.http);


### PR DESCRIPTION
config should be set before curve

# Why

Curve being set before the config. The curve setting logic relies on the config.

# How

Describe how you've approached the problem

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
