### PR TITLE
fix: use correct ecdh key based on specified curve

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,10 +161,14 @@ class EvervaultClient {
   async encrypt(data) {
     if (!Datatypes.isDefined(this._derivedAesKey)) {
       if (!Datatypes.isDefined(this._ecdhTeamKey)) {
-        const { ecdhKey } = await this.http.getCageKey();
+        const result = await this.http.getCageKey();
+        const teamKey =
+          this.curve == EvervaultClient.CURVES.PRIME256V1
+            ? result.ecdhP256Key
+            : result.ecdhKey;
         this.defineHiddenProperty(
           '_ecdhTeamKey',
-          Buffer.from(ecdhKey, 'base64')
+          Buffer.from(teamKey, 'base64')
         );
       }
       this._refreshKeys();

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ class EvervaultClient {
       if (!Datatypes.isDefined(this._ecdhTeamKey)) {
         const result = await this.http.getCageKey();
         const teamKey =
-          this.curve == EvervaultClient.CURVES.PRIME256V1
+          this.curve === EvervaultClient.CURVES.PRIME256V1
             ? result.ecdhP256Key
             : result.ecdhKey;
         this.defineHiddenProperty(


### PR DESCRIPTION
key refresh function was always using the public key for the secp256k1 curve causing encryption with
prime256v1 to fail

# Why

key refresh function was always using the public key for the secp256k1 curve causing encryption with
prime256v1 to fail

# How

Describe how you've approached the problem

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
