### PR TITLE
fix: fix capitalization in curve name and set derived aes key for sec…

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -2,6 +2,8 @@ const crypto = require('crypto');
 const { P256 } = require('../curves');
 const Datatypes = require('../utils/datatypes');
 
+const PRIME256V1 = 'prime256v1';
+
 const generateBytes = (byteLength) => {
   return new Promise((resolve, reject) =>
     crypto.randomBytes(byteLength, (err, buf) => {
@@ -126,7 +128,7 @@ module.exports = (config, http) => {
       }
     );
 
-    if (curve === 'PRIME256V1') {
+    if (curve === PRIME256V1) {
       cipher.setAAD(Buffer.from(ecdhTeamKey, 'base64'));
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,10 @@ class EvervaultClient {
         )
       );
     } else {
-      this._ecdh.computeSecret(this._ecdhTeamKey);
+      this.defineHiddenProperty(
+        '_derivedAesKey',
+        this._ecdh.computeSecret(this._ecdhTeamKey)
+      );
     }
   }
 


### PR DESCRIPTION
…p256k1

# Why

Two issues:
- Check on whether to KDF shared secret was using wrong capitalization on the curve name
- For secp256k1 curve, the derived aes key was not being set

# How

Describe how you've approached the problem

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
