### PR TITLE
Add x509 parse function which supports node pre v15

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ const crypto = require('crypto');
 const tls = require('tls');
 const https = require('https');
 const retry = require('async-retry');
-const { X509Certificate } = require('crypto');
 const { Buffer } = require('buffer');
 
 const HttpsProxyAgent = require('./utils/proxyAgent');
@@ -13,6 +12,7 @@ const {
   cageLock,
   deploy,
   environment,
+  certHelper,
 } = require('./utils');
 const Config = require('./config');
 const { Crypto, Http } = require('./core');
@@ -81,7 +81,7 @@ class EvervaultClient {
     async function updateCertificate() {
       const pem = await evClient.http.getCert();
       let cert = pem.toString();
-      x509 = new X509Certificate(cert);
+      x509 = certHelper.parseX509(cert);
       tls.createSecureContext = (options) => {
         const context = origCreateSecureContext(options);
         context.context.addCACert(pem);

--- a/lib/utils/certHelper.js
+++ b/lib/utils/certHelper.js
@@ -1,0 +1,22 @@
+const { X509Certificate } = require('crypto');
+
+const parseX509 = (cert) => {
+  if (X509Certificate) {
+    return new X509Certificate(cert);
+  } else {
+    const tls = require('tls');
+    const net = require('net');
+
+    const secureContext = tls.createSecureContext({
+      cert,
+    });
+    const secureSocket = new tls.TLSSocket(new net.Socket(), { secureContext });
+    const parsedCert = secureSocket.getCertificate();
+    secureSocket.destroy();
+    return parsedCert;
+  }
+};
+
+module.exports = {
+  parseX509,
+};

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -5,4 +5,5 @@ module.exports = {
   cageLock: require('./cagelock'),
   environment: require('./environment'),
   deploy: require('./deploy'),
+  certHelper: require('./certHelper'),
 };


### PR DESCRIPTION
# Why

The approach we were using for parsing x509 certificates only support node post v15.6.0.

# How

Add support for older node versions in a cert helper module. If node crypto doesn't export an X509Certificate class, fallback to using the tls and net modules to parse the cert.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
