### PR TITLE
fix: bump mocha to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cz-conventional-changelog": "^3.2.0",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
-    "mocha": "^8.4.0",
+    "mocha": "^10.0.0",
     "nock": "^12.0.3",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",


### PR DESCRIPTION
# Why
Mocha contained vulnerabilities that needed to be patched.

# How

- Bump to version `^10.0.0`

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
