### PR TITLE
fix: fixed outbound for when args is an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,10 @@ class EvervaultClient {
     }
 
     function getDomainFromArgs(args) {
+      if (typeof args[0] === 'string') {
+        return new URL(args[0]).host;
+      }
+
       if (args.url) {
         return args.url.match(domainRegex)[0];
       }


### PR DESCRIPTION
# Why
Bug highlighted when using `node-fetch` with Evervault Outbound Interception, `node-fetch` formats its request to `https.request()` as an array which is currently unsupported by the filtration logic in outbound. 

# How
Added a check for if the first argument is a string, if it is it will attempt to parse it as a string.

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
