### PR TITLE
Revert "refactor: debug log output will now contain an Evervault identifier"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,7 +154,7 @@ class EvervaultClient {
       const shouldProxy = domainFilter(domain);
       if (debugRequests) {
         console.log(
-          `EVERVAULT DEBUG :: Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
+          `Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
         );
       }
       args = args.map((arg) => {


### PR DESCRIPTION
Reverts evervault/evervault-node#97 as refactor doesn't trigger a release