### PR TITLE
fix: debug log output will now contain an Evervault identifier

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -150,7 +150,7 @@ class EvervaultClient {
       const shouldProxy = domainFilter(domain);
       if (debugRequests) {
         console.log(
-          `Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
+          `EVERVAULT DEBUG :: Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
         );
       }
       args = args.map((arg) => {


### PR DESCRIPTION
# Why
Its hard to distinguish Evervault debug logs from other libraries

# How

- Add `EVERVAULT DEBUG ::` to distinguish them

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
