### PR TITLE
Eoin/etr 129 update nodejs sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Options to control how your Cage is run
 | async   | Boolean | false     | Run your Cage in async mode. Async Cage runs will be queued for processing.          |
 | version | Number  | undefined | Specify the version of your Cage to run. By default, the latest version will be run. |
 
-### Enable outbound interception for specific domains
+### Enable Outbound Relay for specific domains
 
-You may pass in an array of domains which you **do** want to be intercepted, i.e. requests sent to these domains will be intercepted, and hence will be decrypted. This array is passed in the `decryptionDomains` option. Wildcards domains are supported.
+Outbound Relay will decrypt any Evervault encrypted data sent to a domain that is configured as an Outbound Relay Destination in the [UI](https://app.evervault.com). Setting the `enableOutboundRelay` option to `true` will enable and sync your Outbound Relay destinations with the SDK.
 
 ```javascript
 const evervaultClient = new Evervault('<API-KEY>', {
-  decryptionDomains: ['httpbin.org', 'api.acme.com', '*.acme.com'], // requests to these domains will be sent through Relay
+  enableOutboundRelay: true
 });
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ const DEFAULT_API_URL = 'https://api.evervault.com';
 const DEFAULT_CAGE_RUN_URL = 'https://run.evervault.com';
 const DEFAULT_TUNNEL_HOSTNAME = 'https://relay.evervault.com:443';
 const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
+const DEFAULT_POLL_INTERVAL = 120;
 
 module.exports = (apikey) => ({
   http: {
@@ -16,6 +17,7 @@ module.exports = (apikey) => ({
     responseType: 'json',
     tunnelHostname: process.env.EV_TUNNEL_HOSTNAME || DEFAULT_TUNNEL_HOSTNAME,
     certHostname: process.env.EV_CERT_HOSTNAME || DEFAULT_CA_HOSTNAME,
+    pollInterval: process.env.EV_POLL_INTERVAL || DEFAULT_POLL_INTERVAL,
   },
   encryption: {
     secp256k1: {

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -49,6 +49,23 @@ module.exports = (config) => {
     return response.body;
   };
 
+  const getRelayOutboundConfig = async (debugRequests) => {
+    if (debugRequests) {
+      console.log(
+        'EVERVAULT DEBUG :: Polling Evervault API for outbound config'
+      );
+    }
+    const response = await get('v2/relay-outbound').catch((e) => {
+      throw new errors.RelayOutboundConfigError(
+        `An error occoured while retrieving the Relay Outbound configuration: ${e}`
+      );
+    });
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return response.body;
+    }
+    throw errors.mapApiResponseToError(response);
+  };
+
   const buildRunHeaders = ({ version, async }) => {
     const headers = {};
     if (version) {
@@ -86,5 +103,11 @@ module.exports = (config) => {
     );
   };
 
-  return { getCageKey, runCage, getCert, createRunToken };
+  return {
+    getCageKey,
+    runCage,
+    getCert,
+    createRunToken,
+    getRelayOutboundConfig,
+  };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,8 @@
 const crypto = require('crypto');
-const tls = require('tls');
 const https = require('https');
 const retry = require('async-retry');
 const { Buffer } = require('buffer');
 
-const HttpsProxyAgent = require('./utils/proxyAgent');
 const {
   Datatypes,
   errors,
@@ -12,16 +10,14 @@ const {
   cageLock,
   deploy,
   environment,
-  certHelper,
   validationHelper,
+  httpsHelper,
+  polling,
 } = require('./utils');
 const Config = require('./config');
 const { Crypto, Http } = require('./core');
 
-const origCreateSecureContext = tls.createSecureContext;
 const originalRequest = https.request;
-const domainRegex =
-  /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
 class EvervaultClient {
   static CURVES = {
@@ -54,17 +50,48 @@ class EvervaultClient {
     this.retry = options.retry;
     this.http = Http(this.config.http);
     this.crypto = Crypto(this.config.encryption[curve], this.http);
+    this.httpsHelper = httpsHelper;
+    this.pollInterval = this.config.http.pollInterval * 1000;
+    this.polling = polling;
 
     this.defineHiddenProperty(
       '_ecdh',
       crypto.createECDH(this.config.encryption[curve].ecdhCurve)
     );
 
-    if (options.intercept || options.ignoreDomains) {
+    this._shouldOverloadHttpModule(options, apiKey);
+  }
+
+  async _shouldOverloadHttpModule(options, apiKey) {
+    if (
+      options.intercept ||
+      options.ignoreDomains ||
+      options.decryptionDomains
+    ) {
       console.warn(
         '\x1b[43m\x1b[30mWARN\x1b[0m The `intercept` and `ignoreDomains` config options in Evervault Node.js SDK are deprecated and slated for removal.',
         '\n\x1b[43m\x1b[30mWARN\x1b[0m Please switch to the `decryptionDomains` config option.',
         '\n\x1b[43m\x1b[30mWARN\x1b[0m More details: https://docs.evervault.com/reference/nodejs-sdk#evervaultsdk'
+      );
+    } else if (options.intercept !== false && options.enableOutboundRelay) {
+      // ^ preserves backwards compatibility with if relay is explictly turned off
+      this.intervalId = await this.polling.pollRelayOutboundConfig(
+        this.pollInterval,
+        async () => {
+          try {
+            const configResponse = await this.http.getRelayOutboundConfig(
+              Boolean(options.debugRequests)
+            );
+            this.relayOutboundConfig = Object.values(
+              configResponse.outboundDestinations
+            ).map((config) => config.destinationDomain);
+          } catch (_e) {
+            console.error(
+              'EVERVAULT :: An error occurred while attempting to refresh the outbound relay config'
+            );
+          }
+        },
+        Boolean(options.debugRequests)
       );
     }
 
@@ -72,11 +99,13 @@ class EvervaultClient {
       const decryptionDomainsFilter = this._decryptionDomainsFilter(
         options.decryptionDomains
       );
-      this._overloadHttpsModule(
+      await this.httpsHelper.overloadHttpsModule(
         apiKey,
         this.config.http.tunnelHostname,
         decryptionDomainsFilter,
-        Boolean(options.debugRequests)
+        Boolean(options.debugRequests),
+        this.http,
+        originalRequest
       );
     } else if (
       options.intercept === true ||
@@ -86,92 +115,29 @@ class EvervaultClient {
       const ignoreDomainsFilter = this._ignoreDomainFilter(
         options.ignoreDomains
       );
-      this._overloadHttpsModule(
+      await this.httpsHelper.overloadHttpsModule(
         apiKey,
         this.config.http.tunnelHostname,
         ignoreDomainsFilter,
-        Boolean(options.debugRequests)
+        Boolean(options.debugRequests),
+        this.http,
+        originalRequest
+      );
+    } else if (
+      this.relayOutboundConfig &&
+      Object.keys(this.relayOutboundConfig).length > 0
+    ) {
+      await this.httpsHelper.overloadHttpsModule(
+        apiKey,
+        this.config.http.tunnelHostname,
+        this._relayOutboundConfigDomainFilter(),
+        Boolean(options.debugRequests),
+        this.http,
+        originalRequest
       );
     } else {
       https.request = originalRequest;
     }
-  }
-
-  /**
-   * @param {String} apiKey
-   * @returns {void}
-   */
-  async _overloadHttpsModule(
-    apiKey,
-    tunnelHostname,
-    domainFilter,
-    debugRequests = false
-  ) {
-    let x509 = null;
-    let evClient = this;
-    async function updateCertificate() {
-      const pem = await evClient.http.getCert();
-      let cert = pem.toString();
-      x509 = certHelper.parseX509(cert);
-      tls.createSecureContext = (options) => {
-        const context = origCreateSecureContext(options);
-        context.context.addCACert(pem);
-        return context;
-      };
-    }
-
-    function isCertificateInvalid() {
-      if (!Datatypes.isDefined(x509)) {
-        return true;
-      }
-      const epoch = new Date().valueOf();
-      return (
-        epoch > new Date(x509.validTo).valueOf() ||
-        epoch < new Date(x509.validFrom).valueOf()
-      );
-    }
-
-    function getDomainFromArgs(args) {
-      if (typeof args[0] === 'string') {
-        return new URL(args[0]).host;
-      }
-
-      if (args.url) {
-        return args.url.match(domainRegex)[0];
-      }
-
-      let domain;
-      for (const arg of args) {
-        if (arg instanceof Object) {
-          domain = domain || arg.hostname || arg.host;
-        }
-      }
-      return domain;
-    }
-
-    function wrapMethodRequest(...args) {
-      const domain = getDomainFromArgs(args);
-      const shouldProxy = domainFilter(domain);
-      if (debugRequests) {
-        console.log(
-          `EVERVAULT DEBUG :: Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
-        );
-      }
-      args = args.map((arg) => {
-        if (shouldProxy && arg instanceof Object) {
-          arg.agent = new HttpsProxyAgent(
-            tunnelHostname,
-            updateCertificate,
-            isCertificateInvalid
-          );
-          arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
-        }
-        return arg;
-      });
-      return originalRequest.apply(this, args);
-    }
-
-    https.request = wrapMethodRequest;
   }
 
   _alwaysIgnoreDomains() {
@@ -223,6 +189,16 @@ class EvervaultClient {
 
     return (domain) =>
       !this._isIgnoreRequest(domain, ignoreExact, ignoreEndsWith);
+  }
+
+  _relayOutboundConfigDomainFilter() {
+    return (domain) => {
+      return this._isDecryptionDomain(
+        domain,
+        this.relayOutboundConfig,
+        this._alwaysIgnoreDomains()
+      );
+    };
   }
 
   _isIgnoreRequest(domain, ignoreExact, ignoreEndsWith) {

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -21,6 +21,8 @@ class ForbiddenIPError extends EvervaultError {}
 
 class DecryptError extends EvervaultError {}
 
+class RelayOutboundConfigError extends EvervaultError {}
+
 const mapApiResponseToError = ({ statusCode, body, headers }) => {
   if (statusCode === 401) return new ApiKeyError('Invalid Api Key provided.');
   if (
@@ -58,4 +60,5 @@ module.exports = {
   CertError,
   DecryptError,
   ForbiddenIPError,
+  RelayOutboundConfigError,
 };

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -1,0 +1,90 @@
+const https = require('https');
+const tls = require('tls');
+const Datatypes = require('./datatypes');
+const certHelper = require('./certHelper');
+const HttpsProxyAgent = require('./proxyAgent');
+
+const origCreateSecureContext = tls.createSecureContext;
+
+/**
+ * @param {String} apiKey
+ * @returns {void}
+ */
+const overloadHttpsModule = async (
+  apiKey,
+  tunnelHostname,
+  domainFilter,
+  debugRequests = false,
+  evClient,
+  originalRequest
+) => {
+  let x509 = null;
+
+  async function updateCertificate() {
+    const pem = await evClient.getCert();
+    let cert = pem.toString();
+    x509 = certHelper.parseX509(cert);
+    tls.createSecureContext = (options) => {
+      const context = origCreateSecureContext(options);
+      context.context.addCACert(pem);
+      return context;
+    };
+  }
+
+  function isCertificateInvalid() {
+    if (!Datatypes.isDefined(x509)) {
+      return true;
+    }
+    const epoch = new Date().valueOf();
+    return (
+      epoch > new Date(x509.validTo).valueOf() ||
+      epoch < new Date(x509.validFrom).valueOf()
+    );
+  }
+
+  function getDomainFromArgs(args) {
+    if (typeof args[0] === 'string') {
+      return new URL(args[0]).host;
+    }
+
+    if (args.url) {
+      return args.url.match(domainRegex)[0];
+    }
+
+    let domain;
+    for (const arg of args) {
+      if (arg instanceof Object) {
+        domain = domain || arg.hostname || arg.host;
+      }
+    }
+    return domain;
+  }
+
+  function wrapMethodRequest(...args) {
+    const domain = getDomainFromArgs(args);
+    const shouldProxy = domainFilter(domain);
+    if (debugRequests) {
+      console.log(
+        `EVERVAULT DEBUG :: Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
+      );
+    }
+    args = args.map((arg) => {
+      if (shouldProxy && arg instanceof Object) {
+        arg.agent = new HttpsProxyAgent(
+          tunnelHostname,
+          updateCertificate,
+          isCertificateInvalid
+        );
+        arg.headers = { ...arg.headers, 'Proxy-Authorization': apiKey };
+      }
+      return arg;
+    });
+    return originalRequest.apply(this, args);
+  }
+
+  https.request = wrapMethodRequest;
+};
+
+module.exports = {
+  overloadHttpsModule,
+};

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -7,4 +7,6 @@ module.exports = {
   deploy: require('./deploy'),
   certHelper: require('./certHelper'),
   validationHelper: require('./validationHelper'),
+  httpsHelper: require('./httpsHelper'),
+  polling: require('./polling'),
 };

--- a/lib/utils/polling.js
+++ b/lib/utils/polling.js
@@ -1,0 +1,19 @@
+const pollRelayOutboundConfig = async (pollInterval, cb, debugRequests) => {
+  // setInterval always waits for the delay before firing the first time, but we want to do an initial poll right away
+  try {
+    await cb(debugRequests);
+  } catch (_e) {
+    // catch initial error so the interval starts
+    console.error(
+      'EVERVAULT :: An error occurred while attempting to refresh the outbound relay config'
+    );
+  }
+  return setInterval(
+    async (debugRequests) => await cb(debugRequests),
+    pollInterval
+  );
+};
+
+module.exports = {
+  pollRelayOutboundConfig,
+};

--- a/tests/core/http.test.js
+++ b/tests/core/http.test.js
@@ -154,4 +154,58 @@ describe('Http Module', () => {
       });
     });
   });
+
+  describe('getRelayOutboundConfig', () => {
+    context('Given an api key', () => {
+      context('Request is successful', () => {
+        let getRelayOutboundConfigNock;
+        const testResponse = { test: 'response' };
+        before(() => {
+          getRelayOutboundConfigNock = setupNock()
+            .get('/v2/relay-outbound')
+            .reply(200, testResponse);
+        });
+
+        it('It gets the relay outbound config with the api key', () => {
+          return testHttpClient.getRelayOutboundConfig().then((res) => {
+            expect(getRelayOutboundConfigNock.isDone()).to.be.true;
+            expect(res).to.deep.equal(testResponse);
+          });
+        });
+      });
+      context('Request fails', () => {
+        context('Response is a 401', () => {
+          let getRelayOutboundConfigNock;
+          const testResponse = { errorType: 'Unauthorized' };
+          before(() => {
+            getRelayOutboundConfigNock = setupNock()
+              .get('/v2/relay-outbound')
+              .reply(401, testResponse);
+          });
+
+          it('It gets the relay outbound config with the api key', () => {
+            return testHttpClient.getRelayOutboundConfig().catch((err) => {
+              expect(getRelayOutboundConfigNock.isDone()).to.be.true;
+              expect(err).to.be.instanceOf(errors.ApiKeyError);
+            });
+          });
+        });
+      });
+      context('Request throws an error', () => {
+        let getRelayOutboundConfigNock;
+        before(() => {
+          getRelayOutboundConfigNock = setupNock()
+            .get('/v2/relay-outbound')
+            .replyWithError('An error occurred');
+        });
+        it('Throws a RelayOutboundConfig Error', () => {
+          return testHttpClient.getRelayOutboundConfig().catch((err) => {
+            expect(getRelayOutboundConfigNock.isDone()).to.be.true;
+            console.error(err);
+            expect(err).to.be.instanceOf(errors.RelayOutboundConfigError);
+          });
+        });
+      });
+    });
+  });
 });

--- a/tests/httpHelper.test.js
+++ b/tests/httpHelper.test.js
@@ -1,0 +1,49 @@
+const { httpsHelper } = require('../lib/utils');
+const sinon = require('sinon');
+const { expect } = require('chai');
+const https = require('https');
+const phin = require('phin');
+const fs = require('fs');
+
+describe('overload https requests', () => {
+  const apiKey = 'test-api-key';
+  const tunnelHostname = 'relay.evervault.com';
+  const shouldNotFilter = (_domain) => {
+    return false;
+  };
+  debugRequests = false;
+  evClient = {
+    getCert: sinon
+      .stub()
+      .returns(fs.readFileSync(`${__dirname}/utilities/ssl-cert-snakeoil.pem`)),
+  };
+  origionalRequest = https.request;
+  const testUrl = 'https://evervault.com';
+
+  afterEach(() => {
+    https.request = origionalRequest;
+  });
+
+  const wasProxied = (result) => {
+    return result.socket._parent
+      ? result.socket._parent._host === 'relay.evervault.com'
+      : false;
+  };
+
+  context('will use filter domain func to ignore domains', () => {
+    it('should apply filter to requests', async () => {
+      await httpsHelper.overloadHttpsModule(
+        apiKey,
+        tunnelHostname,
+        shouldNotFilter,
+        debugRequests,
+        evClient,
+        origionalRequest
+      );
+
+      return await phin(testUrl).then((result) => {
+        expect(wasProxied(result)).to.be.false;
+      });
+    });
+  });
+});

--- a/tests/utilities/fixtures.js
+++ b/tests/utilities/fixtures.js
@@ -1,0 +1,37 @@
+const relayOutboundResponse = {
+  appUuid: 'app_5b849d3d269d',
+  teamUuid: '2ef8d35ce668',
+  strictMode: true,
+  outboundDestinations: {
+    'destination1.evervault.test': {
+      id: 153,
+      appUuid: 'app_5b849d3d269d',
+      createdAt: '2022-10-07T10:14:18.597Z',
+      updatedAt: '2022-10-07T10:14:18.597Z',
+      deletedAt: null,
+      routeSpecificFieldsToEncrypt: [],
+      deterministicFieldsToEncrypt: [],
+      encryptEmptyStrings: true,
+      curve: 'secp256k1',
+      uuid: 'outbound_destination_f0d7b61c8d52',
+      destinationDomain: 'destination1.evervault.test',
+    },
+    'destination2.evervault.test': {
+      id: 154,
+      appUuid: 'app_5b849d3d269d',
+      createdAt: '2022-10-07T11:18:39.447Z',
+      updatedAt: '2022-10-07T11:18:39.447Z',
+      deletedAt: null,
+      routeSpecificFieldsToEncrypt: [],
+      deterministicFieldsToEncrypt: [],
+      encryptEmptyStrings: true,
+      curve: 'secp256k1',
+      uuid: 'outbound_destination_73a9b729f81e',
+      destinationDomain: 'destination2.evervault.test',
+    },
+  },
+};
+
+module.exports = {
+  relayOutboundResponse,
+};


### PR DESCRIPTION
# Why

The Node SDK needs to be able to pull Relay Outbound configs from the API

# How
- Add a call to the API to retrieve the outbound relay config if the user doesn't specify any options
- The API call uses a setInterval set to 5 mins to poll the API
- `overloadHttpsModule` was moved into its own helper module to make it more testable, `nock` does not play well with tests that override https.
- Biggest change to the tests was making the `wasProxied` method check against a stub instead of a socket.

# Tests
- [X] Tested with express API

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
