### PR TITLE
fix: add error to debug log for outbound config request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,9 +85,9 @@ class EvervaultClient {
             this.relayOutboundConfig = Object.values(
               configResponse.outboundDestinations
             ).map((config) => config.destinationDomain);
-          } catch (_e) {
+          } catch (e) {
             console.error(
-              'EVERVAULT :: An error occurred while attempting to refresh the outbound relay config'
+              `EVERVAULT :: An error occurred while attempting to refresh the outbound relay config ${e}`
             );
           }
         },


### PR DESCRIPTION
# Why
There are errors in Lambda when pulling configs from Cloudfront

# How
- Add error message to the debug logs

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
