### PR TITLE
feat: remove decryption domains from the deprecation list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,14 +63,9 @@ class EvervaultClient {
   }
 
   async _shouldOverloadHttpModule(options, apiKey) {
-    if (
-      options.intercept ||
-      options.ignoreDomains ||
-      options.decryptionDomains
-    ) {
+    if (options.intercept || options.ignoreDomains) {
       console.warn(
         '\x1b[43m\x1b[30mWARN\x1b[0m The `intercept` and `ignoreDomains` config options in Evervault Node.js SDK are deprecated and slated for removal.',
-        '\n\x1b[43m\x1b[30mWARN\x1b[0m Please switch to the `decryptionDomains` config option.',
         '\n\x1b[43m\x1b[30mWARN\x1b[0m More details: https://docs.evervault.com/reference/nodejs-sdk#evervaultsdk'
       );
     } else if (options.intercept !== false && options.enableOutboundRelay) {


### PR DESCRIPTION
# Why
Decryption domains should not be on the deprecated list

# How
- Removed as deprecated option

# Checklist
- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
