### PR TITLE
refactor(sdk): README & API cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Evervault Node.js SDK
 
-The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Function. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
+The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Functions. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Evervault Node.js SDK
 
-The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
+The [Evervault](https://evervault.com) Node.js SDK is a toolkit for encrypting data as it enters your server, and working with Function. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
 
 ## Getting Started
 
 Before starting with the Evervault Node.js SDK, you will need to [create an account](https://app.evervault.com/register) and a team.
 
-For full installation support, [book time here](https://calendly.com/evervault/cages-onboarding).
+For full installation support, [book time here](https://calendly.com/evervault/support).
 
 ## Documentation
 
@@ -37,8 +37,8 @@ const evervaultClient = new Evervault('<API-KEY>');
 // Encrypt your sensitive data
 const encrypted = await evervaultClient.encrypt({ ssn: '012-34-5678' });
 
-// Process the encrypted data in a Cage
-const result = await evervaultClient.run('<CAGE_NAME>', encrypted);
+// Process the encrypted data in a Function
+const result = await evervaultClient.run('<FUNCTION_NAME>', encrypted);
 ```
 
 ## Reference
@@ -47,7 +47,7 @@ The Evervault Node.js SDK exposes three functions.
 
 ### evervault.encrypt()
 
-`evervault.encrypt()`encrypts data for use in your [Cages](https://docs.evervault.com/tutorial). To encrypt data at the server, simply pass an object or string into the evervault.encrypt() function. Store the encrypted data in your database as normal.
+`evervault.encrypt()`encrypts data for use in your [Functions](https://docs.evervault.com/tutorial). To encrypt data at the server, simply pass an object or string into the evervault.encrypt() function. Store the encrypted data in your database as normal.
 
 ```javascript
 async evervault.encrypt(data: Object | String);
@@ -59,26 +59,39 @@ async evervault.encrypt(data: Object | String);
 
 ### evervault.run()
 
-`evervault.run()` invokes a Cage with a given payload.
+`evervault.run()` invokes a Function with a given payload.
 
 ```javascript
-async evervault.run(cageName: String, payload: Object[, options: Object]);
+async evervault.run(functionName: String, payload: Object[, options: Object]);
 ```
 
 | Parameter | Type   | Description                                   |
 | --------- | ------ | --------------------------------------------- |
-| cageName  | String | Name of the Cage to be run                    |
-| data      | Object | Payload for the Cage                          |
-| options   | Object | [Options for the Cage run](#Cage-Run-Options) |
+| functionName  | String | Name of the Function to be run                    |
+| data      | Object | Payload for the Function                          |
+| options   | Object | [Options for the Function run](#Function-Run-Options) |
 
-#### Cage Run Options
+#### Function Run Options
 
-Options to control how your Cage is run
+Options to control how your Function is run
 
 | Option  | Type    | Default   | Description                                                                          |
 | ------- | ------- | --------- | ------------------------------------------------------------------------------------ |
-| async   | Boolean | false     | Run your Cage in async mode. Async Cage runs will be queued for processing.          |
-| version | Number  | undefined | Specify the version of your Cage to run. By default, the latest version will be run. |
+| async   | Boolean | false     | Run your Function in async mode. Async Function runs will be queued for processing.          |
+| version | Number  | undefined | Specify the version of your Function to run. By default, the latest version will be run. |
+
+### evervault.createRunToken()
+
+`evervault.createRunToken()` creates a single use, time bound token for invoking a Function.
+
+```javascript
+async evervault.createRunToken(functionName: String, payload: Object);
+```
+
+| Parameter     | Type   | Description                                              |
+| ------------- | ------ | -------------------------------------------------------- |
+| functionName  | String | Name of the Function the run token should be created for |
+| data          | Object | Payload that the token can be used with                  |
 
 ### Enable Outbound interception for specific domains
 
@@ -89,19 +102,6 @@ const evervaultClient = new Evervault('<API-KEY>', {
   decryptionDomains: ['httpbin.org', 'api.acme.com', '*.acme.com'], // requests to these domains will be sent through Relay
 });
 ```
-
-### evervault.createRunToken()
-
-`evervault.createRunToken()` creates a single use, time bound token for invoking a cage.
-
-```javascript
-async evervault.createRunToken(cageName: String, payload: Object);
-```
-
-| Parameter | Type   | Description                                          |
-| --------- | ------ | ---------------------------------------------------- |
-| cageName  | String | Name of the Cage the run token should be created for |
-| data      | Object | Payload that the token can be used with              |
 
 ## Contributing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,26 +272,26 @@ class EvervaultClient {
   }
 
   /**
-   * @param {String} cageName
+   * @param {String} functionName
    * @param {Object} payload
    * @param {Object} [options]
    * @returns {Promise<*>}
    */
-  async run(cageName, payload, options = {}) {
+  async run(functionName, payload, options = {}) {
     validationHelper.validatePayload(payload);
-    validationHelper.validateCageName(cageName);
+    validationHelper.validateFunctionName(functionName);
     validationHelper.validateOptions(options);
 
     if (this.retry) {
       const response = await retry(
         async () => {
-          return await this.http.runCage(cageName, payload, options);
+          return await this.http.runCage(functionName, payload, options);
         },
         { retries: 3 }
       );
       return response.body;
     } else {
-      const response = await this.http.runCage(cageName, payload, options);
+      const response = await this.http.runCage(functionName, payload, options);
       return response.body;
     }
   }
@@ -302,6 +302,9 @@ class EvervaultClient {
    * @returns {Function}
    */
   cagify(cageName, func) {
+    console.warn(
+      '\x1b[43m\x1b[30mWARN\x1b[0m The `cagify` method is deprecated and slated for removal.'
+    );
     if (!Datatypes.isFunction(func)) {
       throw new errors.EvervaultError(
         'Cagify must be provided with a function to run'
@@ -358,31 +361,34 @@ class EvervaultClient {
   }
 
   /**
-   * @param {String} cageName
+   * @param {String} functionName
    * @param {Object} data
    * @param {Object} options
    * @returns {Promise<*>}
    */
-  async encryptAndRun(cageName, data, options) {
+  async encryptAndRun(functionName, data, options) {
+    console.warn(
+      '\x1b[43m\x1b[30mWARN\x1b[0m The `encrypt_and_run` method is deprecated and slated for removal. Please use the `encrypt` and `run` methods instead.'
+    );
     validationHelper.validatePayload(data);
-    validationHelper.validateCageName(cageName);
+    validationHelper.validateFunctionName(functionName);
     validationHelper.validateOptions(options);
 
     const payload = await this.encrypt(data);
 
-    return await this.run(cageName, payload, options);
+    return await this.run(functionName, payload, options);
   }
 
   /**
-   * @param {String} cageName
+   * @param {String} functionName
    * @param {Object} payload
    * @returns {Promise<*>}
    */
-  async createRunToken(cageName, payload) {
+  async createRunToken(functionName, payload) {
     validationHelper.validatePayload(payload);
-    validationHelper.validateCageName(cageName);
+    validationHelper.validateFunctionName(functionName);
 
-    const response = await this.http.createRunToken(cageName, payload);
+    const response = await this.http.createRunToken(functionName, payload);
     return response.body;
   }
 

--- a/lib/utils/validationHelper.js
+++ b/lib/utils/validationHelper.js
@@ -7,7 +7,7 @@ const validatePayload = (payload) => {
   }
 };
 
-const validateCageName = (cageName) => {
+const validateFunctionName = (cageName) => {
   if (!Datatypes.isString(cageName))
     throw new errors.EvervaultError('Cage name invalid');
 };
@@ -24,6 +24,6 @@ const validateOptions = (options = {}) => {
 
 module.exports = {
   validatePayload,
-  validateCageName,
+  validateFunctionName,
   validateOptions,
 };


### PR DESCRIPTION
# Why
The README & Client API still used the Cage product name. 

# How
The following changes have been implemented:
- Rename `cage` API arguments to `function`
- Marked deprecated client methods as deprecated
- Update README
