### PR TITLE
chore: bump version of node bot in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - run: npm ci
       - run: npm test
       - run: npx semantic-release


### PR DESCRIPTION
# Why
Semantic release bot only runs on node >= 18 and we were using node 14.

# How

Bumped the version of node in the workflow

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
