### PR TITLE
fix(cageattestation): update attestation bindings to 0.1.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "async-retry": "^1.3.3",
         "escodegen": "^1.14.3",
         "esprima": "^4.0.1",
-        "evervault-attestation-bindings": "*",
         "haikunator": "^2.1.2",
         "konan": "^2.1.1",
         "lodash": "^4.17.21",
@@ -39,7 +38,7 @@
         "sinon-chai": "^3.5.0"
       },
       "optionalDependencies": {
-        "evervault-attestation-bindings": "^0.1.0-alpha.2"
+        "evervault-attestation-bindings": "^0.1.0-alpha.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2102,34 +2101,32 @@
       }
     },
     "node_modules/evervault-attestation-bindings": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-nbcwZh+Uz8TBXtMavZjJ/UbSWU6JTcz3X+k3EDF5TnHcFyPI6jggPnLXxUBth6/mtwuXFQ+nZ3ilWLAV6mXgaw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-/H9yyW7WY2XXIdIUGAAu6GIFuhmM+q/m+RcPO2j13KwaqmiDT3hzMiY3C8SP1refEr1oANy+l1wsEgSo+VbUpg==",
       "optional": true,
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-freebsd-x64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-arm64-msvc": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.2"
+        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.3"
       }
     },
     "node_modules/evervault-attestation-bindings-android-arm-eabi": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-V+S35YS4tO23Wn3ALdoUHeDc6HQIMh7YrDP2SxWz7XHKmlyYthYbewsvdJdZedgeNz7aaN7PRO/4syXEDIAE2w==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-OCAyKcXNiwl2glBFudxMhTCLPa52cL7PH9BsfR5NcyF1PjiiWqSLACDqBiRcihrCkbnOm4FD74q+8Vt8jILD5Q==",
       "cpu": [
         "arm"
       ],
@@ -2142,9 +2139,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-android-arm64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-sfNeOD00A7EbNTVq27x6xu13wUFT1HEqolDKQZiQ/6H/diyxZTUwKCXVgAWCsAC3CjRhyRWP8ba+Qk9JNqQaQA==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-C6scS1nyekml+7PVkhCeFcYVdi6TPgeOmrzXKpuo26puk9YFHUE6nbvWRwJSkTNLvdSWEcNkr4rU3IDspZ8mWQ==",
       "cpu": [
         "arm64"
       ],
@@ -2157,9 +2154,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-arm64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-0F7WCqWgSRwyauWVu0qZzeZw+lb9TmwNO+qqnoNxLzIu0oPDBaqGK/xOQpTUUVgNgX9+kG5VV/NJVlCpIlzqJw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-LmDX/RDP3OiWOd87YzGWwJxSc+g0g+ecqIk7XBUIfk8VCt15GiGmDhoieG7inCuDZDAMlo5G+kK3uR+pzajbYw==",
       "cpu": [
         "arm64"
       ],
@@ -2172,9 +2169,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-universal": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-juVR9xwjaeE2hQfytd1+7mn7xzs4Fk9n1LMoWXtg1adesx9g0xlDA10iNBkqbF6NLjT52xa8qLCAutezEt+flg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-74fDH5CZsxOr4OAUHmjRDUstkzuool19IsAW7jeYg9OcQVpaSZOylNoiciwzQM0SA0QezSDtEtj+Fr0BxMDm9A==",
       "optional": true,
       "os": [
         "darwin"
@@ -2184,9 +2181,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-x64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-rAIUKRpixbAjRQWNAqfykchsZKosxR36DnQ/k1khcr1hgdqLcUQs5xPXrc3uZkWOHLtWb1q73WqotiprNWFcIg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-VK4Zmh+TteoAwHjNSahCzpzsUjzECZLNp/gg99guMbwowScTqxApD1T8uaOyiVT1NT+tP8vSiAfKCVAt7EekUQ==",
       "cpu": [
         "x64"
       ],
@@ -2199,9 +2196,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm-gnueabihf": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-wsC0AmOTfoWshC8TCBaajus7ILnc1F7R9QLWLYb0Y47SHvz1YBFSC0oZYJ0qxf5TlAAfwMK+cP7ldTO49VA+2Q==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-DPJmR/bX8o5Sfr63cUR+4seV0yDT5iA8djlL2Jnn2RFucqWZQeLuXmLdVJZAFAdvdRUB1/JVp3LYi0Pvq0jpLg==",
       "cpu": [
         "arm"
       ],
@@ -2214,9 +2211,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm64-gnu": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-Bi+BEXTmYlM+gMTJklxsShQh0KCKoP3zTgY6cig4W7KMgCP0pNAlJ+72ublX0u4AxxysyY+r8hAajMgeDMDvNg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-zLts95/tYFWa+ttdPxY+8ZKhknSM7uTKZ11bmLjqxv+3yPnw11H/YbPMJ6cf/OhHEBNTPINK0gJwx9gUPnP1fg==",
       "cpu": [
         "arm64"
       ],
@@ -2229,9 +2226,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm64-musl": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-3IFOo9B8uFIIjw4slhwHCOufijBA8OUNzPNkamvDXDDMiJZx0r+7EBd3+IOKilAb1gPf9jfuKDOMv49V+6YcOQ==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-zv+70+YD5r4KPqVTxbjoDJcz2wPedtjVYSZLwm0rKotT6opxTWpxv17y35Jy6Q/nNcZuboMh2W8tkPsxehrvIQ==",
       "cpu": [
         "arm64"
       ],
@@ -2244,9 +2241,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-x64-gnu": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-5g+9dhm0RxnppLo6nTESJNoqgKC5oJCXKUZgrSSXJ/eF7AFk8tpQ92bHtff3jSusghW74kc4D25rauhMhjWx9Q==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-w3VPXTgFpSI14vfRzXXIl2JV0iZGcKoM9dI5AVM5fRwR+9RLjoBL0eur8U3Of0EMxT6dHNT4E+qQhVUiZAgYuA==",
       "cpu": [
         "x64"
       ],
@@ -2259,9 +2256,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-x64-musl": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-lszetqa216P2UZdO2WDGOaPPWLb48V4h7/tVVSIK3+sgAES2oCT1KM6RVFrnevZuaQn44WqIUV0czTapWmOncw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-Z6K66TLN9BVYY6sTVmEWaRKKEAOTVdl0AxWh7MdpkGrNdD2Y4awLiaJiYX0nwkxllUhkkEGKlAQGq2zvrNJwtw==",
       "cpu": [
         "x64"
       ],
@@ -2274,9 +2271,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-win32-ia32-msvc": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-8bJ4J68+ZGrDZf7IbgKVxd0yWSd64fPCuckDvMstFFpIU+eZl0FscyHxCGpZTg8IgOKl4+T/h2raoIar5FI18g==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-bbTE4DY+iyoO5rZ+3/L6+MrOjDJD7hnzP4ozlw8tRMobQKDpBNUWP4q97PjM8Pu6pJIqmRg9Emn2cyir+9l0sw==",
       "cpu": [
         "ia32"
       ],
@@ -2289,9 +2286,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-win32-x64-msvc": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-AC5ZCJ5qOH3jtIxyt/kFIaiqkquyma8Aro3LJSKU2C5MUICIYwage3LrzdPrRzC839GZFybZMjcdbLaCsUEhYA==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-vAkh1zy4tgMbxaQJjHEAS0Phl4VY+Bcrl8h61sOnMBh5rZ1mpWNxG1Va2WYlXptN2HnB3KdtzZLOEInfOJ8seA==",
       "cpu": [
         "x64"
       ],
@@ -7262,97 +7259,95 @@
       "version": "2.0.3"
     },
     "evervault-attestation-bindings": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-nbcwZh+Uz8TBXtMavZjJ/UbSWU6JTcz3X+k3EDF5TnHcFyPI6jggPnLXxUBth6/mtwuXFQ+nZ3ilWLAV6mXgaw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-/H9yyW7WY2XXIdIUGAAu6GIFuhmM+q/m+RcPO2j13KwaqmiDT3hzMiY3C8SP1refEr1oANy+l1wsEgSo+VbUpg==",
       "optional": true,
       "requires": {
-        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-freebsd-x64": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-arm64-msvc": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.2",
-        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.2"
+        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.3",
+        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.3"
       }
     },
     "evervault-attestation-bindings-android-arm-eabi": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-V+S35YS4tO23Wn3ALdoUHeDc6HQIMh7YrDP2SxWz7XHKmlyYthYbewsvdJdZedgeNz7aaN7PRO/4syXEDIAE2w==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-OCAyKcXNiwl2glBFudxMhTCLPa52cL7PH9BsfR5NcyF1PjiiWqSLACDqBiRcihrCkbnOm4FD74q+8Vt8jILD5Q==",
       "optional": true
     },
     "evervault-attestation-bindings-android-arm64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-sfNeOD00A7EbNTVq27x6xu13wUFT1HEqolDKQZiQ/6H/diyxZTUwKCXVgAWCsAC3CjRhyRWP8ba+Qk9JNqQaQA==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-C6scS1nyekml+7PVkhCeFcYVdi6TPgeOmrzXKpuo26puk9YFHUE6nbvWRwJSkTNLvdSWEcNkr4rU3IDspZ8mWQ==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-arm64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-0F7WCqWgSRwyauWVu0qZzeZw+lb9TmwNO+qqnoNxLzIu0oPDBaqGK/xOQpTUUVgNgX9+kG5VV/NJVlCpIlzqJw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-LmDX/RDP3OiWOd87YzGWwJxSc+g0g+ecqIk7XBUIfk8VCt15GiGmDhoieG7inCuDZDAMlo5G+kK3uR+pzajbYw==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-universal": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-juVR9xwjaeE2hQfytd1+7mn7xzs4Fk9n1LMoWXtg1adesx9g0xlDA10iNBkqbF6NLjT52xa8qLCAutezEt+flg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-74fDH5CZsxOr4OAUHmjRDUstkzuool19IsAW7jeYg9OcQVpaSZOylNoiciwzQM0SA0QezSDtEtj+Fr0BxMDm9A==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-x64": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-rAIUKRpixbAjRQWNAqfykchsZKosxR36DnQ/k1khcr1hgdqLcUQs5xPXrc3uZkWOHLtWb1q73WqotiprNWFcIg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-VK4Zmh+TteoAwHjNSahCzpzsUjzECZLNp/gg99guMbwowScTqxApD1T8uaOyiVT1NT+tP8vSiAfKCVAt7EekUQ==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm-gnueabihf": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-wsC0AmOTfoWshC8TCBaajus7ILnc1F7R9QLWLYb0Y47SHvz1YBFSC0oZYJ0qxf5TlAAfwMK+cP7ldTO49VA+2Q==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-DPJmR/bX8o5Sfr63cUR+4seV0yDT5iA8djlL2Jnn2RFucqWZQeLuXmLdVJZAFAdvdRUB1/JVp3LYi0Pvq0jpLg==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm64-gnu": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-Bi+BEXTmYlM+gMTJklxsShQh0KCKoP3zTgY6cig4W7KMgCP0pNAlJ+72ublX0u4AxxysyY+r8hAajMgeDMDvNg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-zLts95/tYFWa+ttdPxY+8ZKhknSM7uTKZ11bmLjqxv+3yPnw11H/YbPMJ6cf/OhHEBNTPINK0gJwx9gUPnP1fg==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm64-musl": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-3IFOo9B8uFIIjw4slhwHCOufijBA8OUNzPNkamvDXDDMiJZx0r+7EBd3+IOKilAb1gPf9jfuKDOMv49V+6YcOQ==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-zv+70+YD5r4KPqVTxbjoDJcz2wPedtjVYSZLwm0rKotT6opxTWpxv17y35Jy6Q/nNcZuboMh2W8tkPsxehrvIQ==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-x64-gnu": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-5g+9dhm0RxnppLo6nTESJNoqgKC5oJCXKUZgrSSXJ/eF7AFk8tpQ92bHtff3jSusghW74kc4D25rauhMhjWx9Q==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-w3VPXTgFpSI14vfRzXXIl2JV0iZGcKoM9dI5AVM5fRwR+9RLjoBL0eur8U3Of0EMxT6dHNT4E+qQhVUiZAgYuA==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-x64-musl": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-lszetqa216P2UZdO2WDGOaPPWLb48V4h7/tVVSIK3+sgAES2oCT1KM6RVFrnevZuaQn44WqIUV0czTapWmOncw==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-Z6K66TLN9BVYY6sTVmEWaRKKEAOTVdl0AxWh7MdpkGrNdD2Y4awLiaJiYX0nwkxllUhkkEGKlAQGq2zvrNJwtw==",
       "optional": true
     },
     "evervault-attestation-bindings-win32-ia32-msvc": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-8bJ4J68+ZGrDZf7IbgKVxd0yWSd64fPCuckDvMstFFpIU+eZl0FscyHxCGpZTg8IgOKl4+T/h2raoIar5FI18g==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-bbTE4DY+iyoO5rZ+3/L6+MrOjDJD7hnzP4ozlw8tRMobQKDpBNUWP4q97PjM8Pu6pJIqmRg9Emn2cyir+9l0sw==",
       "optional": true
     },
     "evervault-attestation-bindings-win32-x64-msvc": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-AC5ZCJ5qOH3jtIxyt/kFIaiqkquyma8Aro3LJSKU2C5MUICIYwage3LrzdPrRzC839GZFybZMjcdbLaCsUEhYA==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.3.tgz",
+      "integrity": "sha512-vAkh1zy4tgMbxaQJjHEAS0Phl4VY+Bcrl8h61sOnMBh5rZ1mpWNxG1Va2WYlXptN2HnB3KdtzZLOEInfOJ8seA==",
       "optional": true
     },
     "execa": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     }
   },
   "optionalDependencies": {
-    "evervault-attestation-bindings": "^0.1.0-alpha.2"
+    "evervault-attestation-bindings": "^0.1.0-alpha.3"
   }
 }


### PR DESCRIPTION
# Why

Attestation bindings platform support was inaccurate in previous version causing a 404 on certain platforms.

# How

Use latest attestation bindings with descoped platform support

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
