### PR TITLE
feat(payloadvalidator): allow null or undefined runtoken payloads

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -114,9 +114,9 @@ module.exports = (config) => {
     );
   };
 
-  const createRunToken = (cageName, payload) => {
+  const createRunToken = (functionName, payload) => {
     return post(
-      `v2/functions/${cageName}/run-token`,
+      `v2/functions/${functionName}/run-token`,
       {
         ...payload,
       },

--- a/lib/utils/validationHelper.js
+++ b/lib/utils/validationHelper.js
@@ -2,14 +2,17 @@ const errors = require('./errors');
 const Datatypes = require('./datatypes');
 
 const validatePayload = (payload) => {
-  if (!Datatypes.isObjectStrict(payload)) {
-    throw new errors.EvervaultError('Cages must be given an object to run');
+  if (
+    !Datatypes.isObjectStrict(payload) &&
+    (payload != null || payload != undefined)
+  ) {
+    throw new errors.EvervaultError('Functions must be given an object to run');
   }
 };
 
-const validateFunctionName = (cageName) => {
-  if (!Datatypes.isString(cageName))
-    throw new errors.EvervaultError('Cage name invalid');
+const validateFunctionName = (functionName) => {
+  if (!Datatypes.isString(functionName))
+    throw new errors.EvervaultError('Function name invalid');
 };
 
 const validateOptions = (options = {}) => {
@@ -18,7 +21,7 @@ const validateOptions = (options = {}) => {
     Datatypes.isDefined(options.version) &&
     !Datatypes.isNumber(options.version)
   ) {
-    throw new errors.EvervaultError('Cage version must be a number');
+    throw new errors.EvervaultError('Function version must be a number');
   }
 };
 


### PR DESCRIPTION
# Why
Functions should be able to be run using run tokens without pre-approved payloads

# How
Add a check to the payload validator to also allow null or undefined payloads

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
