### PR TITLE
feat: throw error on file size too large

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
 const DEFAULT_CAGES_CA_HOSTNAME = 'https://cages-ca.evervault.com';
 const DEFAULT_CAGES_HOSTNAME = 'cages.evervault.com';
 const DEFAULT_POLL_INTERVAL = 5;
+const DEFAULT_MAX_FILE_SIZE_IN_MB = 25;
 
 module.exports = (apikey) => ({
   http: {
@@ -37,6 +38,8 @@ module.exports = (apikey) => ({
         iss: 'evervault',
         version: 1,
       },
+      maxFileSizeInMB:
+        process.env.EV_MAX_FILE_SIZE_IN_MB || DEFAULT_MAX_FILE_SIZE_IN_MB,
     },
     prime256v1: {
       ecdhCurve: 'prime256v1',
@@ -50,6 +53,8 @@ module.exports = (apikey) => ({
         iss: 'evervault',
         version: 2,
       },
+      maxFileSizeInMB:
+        process.env.EV_MAX_FILE_SIZE_IN_MB || DEFAULT_MAX_FILE_SIZE_IN_MB,
     },
   },
 });

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const { P256 } = require('../curves');
 const Datatypes = require('../utils/datatypes');
+const { errors } = require('../utils');
 
 const PRIME256V1 = 'prime256v1';
 
@@ -18,6 +19,7 @@ const DEFAULT_ENCRYPT_OPTIONS = {
 };
 
 module.exports = (config) => {
+  let MAX_FILE_SIZE_IN_BYTES = config.maxFileSizeInMB * 1024 * 1024;
   const _encryptObject = async (
     curve,
     ecdhTeamKey,
@@ -173,6 +175,12 @@ module.exports = (config) => {
     derivedSecret,
     data
   ) => {
+    const fileSizeInBytes = data.length;
+    if (fileSizeInBytes > MAX_FILE_SIZE_IN_BYTES) {
+      throw new errors.ExceededMaxFileSizeError(
+        `File size must be less than ${config.maxFileSizeInMB}MB`
+      );
+    }
     const keyIv = await generateBytes(config.ivLength);
 
     const cipher = crypto.createCipheriv(

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -25,6 +25,8 @@ class RelayOutboundConfigError extends EvervaultError {}
 
 class CageAttestationError extends EvervaultError {}
 
+class ExceededMaxFileSizeError extends EvervaultError {}
+
 const mapApiResponseToError = ({ statusCode, body, headers }) => {
   if (statusCode === 401) return new ApiKeyError('Invalid Api Key provided.');
   if (
@@ -64,4 +66,5 @@ module.exports = {
   ForbiddenIPError,
   RelayOutboundConfigError,
   CageAttestationError,
+  ExceededMaxFileSizeError,
 };


### PR DESCRIPTION
# Why

We do not support decryption of files >25MB so an error should be thrown if an attempt is made to encrypt a file larger than this size

# How

Added a max file size, compared the file size with this max

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
