### PR TITLE
feat: calculate crc32 sum for files

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const { P256 } = require('../curves');
 const Datatypes = require('../utils/datatypes');
 const { errors } = require('../utils');
-const CRC32 = require('crc-32');
+const CRC32 = require('../utils/crc32');
 
 const PRIME256V1 = 'prime256v1';
 
@@ -224,7 +224,7 @@ module.exports = (config) => {
       Buffer.from(encryptedData),
     ]);
 
-    const crc32Hash = CRC32.buf(fileContents);
+    const crc32Hash = CRC32(fileContents);
 
     const crc32HashBytes = Buffer.alloc(4);
     crc32HashBytes.writeInt32LE(crc32Hash);

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const { P256 } = require('../curves');
 const Datatypes = require('../utils/datatypes');
 const { errors } = require('../utils');
+const CRC32 = require('crc-32');
 
 const PRIME256V1 = 'prime256v1';
 
@@ -147,9 +148,9 @@ module.exports = (config) => {
 
   const _evEncryptedFileVersion = () => {
     if (config.ecdhCurve == 'secp256k1') {
-      return Buffer.from([0x00]);
+      return Buffer.from([0x02]);
     } else if (config.ecdhCurve === 'prime256v1') {
-      return Buffer.from([0x01]);
+      return Buffer.from([0x03]);
     } else {
       throw new Error('Invalid curve specified');
     }
@@ -213,7 +214,7 @@ module.exports = (config) => {
     const offsetToData = Buffer.from([0x37, 0x00]);
     const flags = Buffer.from([0x00]);
 
-    return Buffer.concat([
+    const fileContents = Buffer.concat([
       evEncryptedFileIdentifier,
       versionNumber,
       offsetToData,
@@ -222,6 +223,13 @@ module.exports = (config) => {
       flags,
       Buffer.from(encryptedData),
     ]);
+
+    const crc32Hash = CRC32.buf(fileContents);
+
+    const crc32HashBytes = Buffer.alloc(4);
+    crc32HashBytes.writeInt32LE(crc32Hash);
+
+    return Buffer.concat([fileContents, crc32HashBytes]);
   };
 
   const encrypt = async (

--- a/lib/utils/crc32.js
+++ b/lib/utils/crc32.js
@@ -1,0 +1,29 @@
+const crcTable = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let c = i;
+  for (let j = 0; j < 8; j++) {
+    if (c & 1) {
+      c = 0xedb88320 ^ (c >>> 1);
+    } else {
+      c = c >>> 1;
+    }
+  }
+  crcTable[i] = c;
+}
+
+// calculate a crc32 given an array buffer
+//
+// @param {ArrayBuffer} buffer
+// @return {Number}
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  const len = buffer.byteLength;
+
+  for (let i = 0; i < len; i++) {
+    crc = crcTable[(crc ^ buffer[i]) & 0xff] ^ (crc >>> 8);
+  }
+
+  return crc ^ 0xffffffff;
+}
+
+module.exports = crc32;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "agent-base": "^6.0.2",
         "async-retry": "^1.3.3",
+        "crc-32": "^1.2.2",
         "escodegen": "^1.14.3",
         "esprima": "^4.0.1",
         "haikunator": "^2.1.2",
@@ -1658,6 +1659,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -6974,6 +6986,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "cross-spawn": {
       "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "agent-base": "^6.0.2",
     "async-retry": "^1.3.3",
+    "crc-32": "^1.2.2",
     "escodegen": "^1.14.3",
     "esprima": "^4.0.1",
     "haikunator": "^2.1.2",

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const crypto = require('crypto');
 const Crypto = require('../../lib/core/crypto');
 const { errors } = require('../../lib/utils');
+const crc32 = require('crc-32');
 
 const testApiKey = 'test-api-key';
 const testConfigSecP256k1 =
@@ -115,6 +116,14 @@ describe('Crypto Module', () => {
               Buffer.from([0x00])
             ) == 0
           ).to.be.true;
+
+          // Test that the CRC32 checksum is correct
+          const crc32Checksum = crc32.buf(encryptedFile.subarray(0, -4));
+          const storedCrc32Checksum = encryptedFile.readInt32LE(
+            encryptedFile.length - 4
+          );
+
+          expect(crc32Checksum).to.equal(storedCrc32Checksum);
         });
     });
 

--- a/tests/core/crypto.test.js
+++ b/tests/core/crypto.test.js
@@ -117,7 +117,7 @@ describe('Crypto Module', () => {
             ) == 0
           ).to.be.true;
 
-          // Test that the CRC32 checksum is correct
+          // Test that the CRC32 checksum is correct compared to library implementation
           const crc32Checksum = crc32.buf(encryptedFile.subarray(0, -4));
           const storedCrc32Checksum = encryptedFile.readInt32LE(
             encryptedFile.length - 4


### PR DESCRIPTION
# Why
Need to add crc32 sum for file encryption so that integrity can be checked on files

# How
Added the crc32 sum calculation and bumped the versions

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
