### PR TITLE
feat(cages attestation): allow users to pass in an Array of sets of PCRs for attesting their Cages

### DIFF
--- a/lib/utils/cageAttest.js
+++ b/lib/utils/cageAttest.js
@@ -47,9 +47,15 @@ function attestCageConnection(hostname, cert, cagesAttestationInfo = {}) {
     const cageName = parseCageNameFromHost(hostname);
     // check if PCRs for this cage have been given
     const pcrs = cagesAttestationInfo[cageName];
+    var pcrsList = [];
+    if (Array.isArray(pcrs)) {
+      pcrsList = pcrs;
+    } else if (typeof pcrs === 'object') {
+      pcrsList = [pcrs];
+    }
     const isConnectionValid = attestationBindings.attestConnection(
       cert.raw,
-      pcrs
+      pcrsList
     );
     if (!isConnectionValid) {
       console.warn(

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "sinon-chai": "^3.5.0"
       },
       "optionalDependencies": {
-        "evervault-attestation-bindings": "^0.1.0-alpha.3"
+        "evervault-attestation-bindings": "^0.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2113,32 +2113,32 @@
       }
     },
     "node_modules/evervault-attestation-bindings": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-/H9yyW7WY2XXIdIUGAAu6GIFuhmM+q/m+RcPO2j13KwaqmiDT3hzMiY3C8SP1refEr1oANy+l1wsEgSo+VbUpg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.2.0.tgz",
+      "integrity": "sha512-PUVaekI6EhiI3KONaZSt6X4xu2S9n3s/l04ZXuOvm3cXbPnO4boyFWDL6TkZ3cUK/6LtD0f19MgfT+fpm+qpuw==",
       "optional": true,
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.3"
+        "evervault-attestation-bindings-android-arm-eabi": "0.2.0",
+        "evervault-attestation-bindings-android-arm64": "0.2.0",
+        "evervault-attestation-bindings-darwin-arm64": "0.2.0",
+        "evervault-attestation-bindings-darwin-universal": "0.2.0",
+        "evervault-attestation-bindings-darwin-x64": "0.2.0",
+        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.2.0",
+        "evervault-attestation-bindings-linux-arm64-gnu": "0.2.0",
+        "evervault-attestation-bindings-linux-arm64-musl": "0.2.0",
+        "evervault-attestation-bindings-linux-x64-gnu": "0.2.0",
+        "evervault-attestation-bindings-linux-x64-musl": "0.2.0",
+        "evervault-attestation-bindings-win32-ia32-msvc": "0.2.0",
+        "evervault-attestation-bindings-win32-x64-msvc": "0.2.0"
       }
     },
     "node_modules/evervault-attestation-bindings-android-arm-eabi": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-OCAyKcXNiwl2glBFudxMhTCLPa52cL7PH9BsfR5NcyF1PjiiWqSLACDqBiRcihrCkbnOm4FD74q+8Vt8jILD5Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.2.0.tgz",
+      "integrity": "sha512-LOT8nW8J7n8BOwaJvaHJaDT1R/r6f2OkOL1z8hqXhj5sGYPD6xY0kuA7NNDeCx17YKjLrbySDpJSH9Gl8q25YQ==",
       "cpu": [
         "arm"
       ],
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-android-arm64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-C6scS1nyekml+7PVkhCeFcYVdi6TPgeOmrzXKpuo26puk9YFHUE6nbvWRwJSkTNLvdSWEcNkr4rU3IDspZ8mWQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.2.0.tgz",
+      "integrity": "sha512-w7s3uXr+8ZLRUhWxM4c0dzOfBYOxzpSCH/UF6Tp/VmBOZcsLNDcK34uz8V9HwCu2cyAE0ibelG2sPAPxVgc9OQ==",
       "cpu": [
         "arm64"
       ],
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-arm64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-LmDX/RDP3OiWOd87YzGWwJxSc+g0g+ecqIk7XBUIfk8VCt15GiGmDhoieG7inCuDZDAMlo5G+kK3uR+pzajbYw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-n6DPLVlCKs0usArLhVKokyKP09VkratM/xgjuUKMKHLYfUFOd+YT7TDnqcbD4T8rNZ4KtyDe8CNcDkAF55ecYA==",
       "cpu": [
         "arm64"
       ],
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-universal": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-74fDH5CZsxOr4OAUHmjRDUstkzuool19IsAW7jeYg9OcQVpaSZOylNoiciwzQM0SA0QezSDtEtj+Fr0BxMDm9A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.2.0.tgz",
+      "integrity": "sha512-CFm4Cp3uX9oIIs9uYmI2V/sUtXSNq20VR1qe/n5EZhrFrCTxgEwE4k+Xd8TY+pgYtL2DtP5NzdiLgaPf4Dd2wQ==",
       "optional": true,
       "os": [
         "darwin"
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-darwin-x64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-VK4Zmh+TteoAwHjNSahCzpzsUjzECZLNp/gg99guMbwowScTqxApD1T8uaOyiVT1NT+tP8vSiAfKCVAt7EekUQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.2.0.tgz",
+      "integrity": "sha512-/xBdmtgTTgU2vVFrd1xR/vieyd069Z4h4AY85MpzdXMnc4PB8csp4rMaKNgtWI4DNrqqU6gK5WmODlYlmPUw6A==",
       "cpu": [
         "x64"
       ],
@@ -2208,9 +2208,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm-gnueabihf": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-DPJmR/bX8o5Sfr63cUR+4seV0yDT5iA8djlL2Jnn2RFucqWZQeLuXmLdVJZAFAdvdRUB1/JVp3LYi0Pvq0jpLg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.2.0.tgz",
+      "integrity": "sha512-yIpagNqQuDFaoyqn46tj1LdxhC0LFPfiJxCx58jKZlWIVaTRQGD1hzJN2Hs9MSdt8zW0DCDmsNqMA2XhBJnH4A==",
       "cpu": [
         "arm"
       ],
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm64-gnu": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-zLts95/tYFWa+ttdPxY+8ZKhknSM7uTKZ11bmLjqxv+3yPnw11H/YbPMJ6cf/OhHEBNTPINK0gJwx9gUPnP1fg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.2.0.tgz",
+      "integrity": "sha512-P4ATWOgp7PW06BuXmNVX/hhZZ/Wf/W2Ek+l1Yh/cly6UH3O00h9tSP6kCIEvbMU1D2YaGky3uP8YCNzm0SGXsg==",
       "cpu": [
         "arm64"
       ],
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-arm64-musl": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-zv+70+YD5r4KPqVTxbjoDJcz2wPedtjVYSZLwm0rKotT6opxTWpxv17y35Jy6Q/nNcZuboMh2W8tkPsxehrvIQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.2.0.tgz",
+      "integrity": "sha512-Aw0FGQ1U55AhICYlnyLPeGwEIRmLVaHqZRtoNhwPFYlkkQu+RNBUi+0mLhGLrJ8/CPkPy5o4XJuUByDs7iVWog==",
       "cpu": [
         "arm64"
       ],
@@ -2253,9 +2253,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-x64-gnu": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-w3VPXTgFpSI14vfRzXXIl2JV0iZGcKoM9dI5AVM5fRwR+9RLjoBL0eur8U3Of0EMxT6dHNT4E+qQhVUiZAgYuA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-6P1P+oy/Z3tW+FA485DCp6fKMDY68aP+HGCMk8bS231uziWqJw03d9PaetjXWda1oZFpt1pJrAFlsrl7ahTd/Q==",
       "cpu": [
         "x64"
       ],
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-linux-x64-musl": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-Z6K66TLN9BVYY6sTVmEWaRKKEAOTVdl0AxWh7MdpkGrNdD2Y4awLiaJiYX0nwkxllUhkkEGKlAQGq2zvrNJwtw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.2.0.tgz",
+      "integrity": "sha512-1lDtFUBDf9khE5IxYojQyBnvPZ5D8PfSxNECSm0GnoTyrnQhPTgEvzxk8lorbTfivaehD/x6RnjjDudI2EVVFQ==",
       "cpu": [
         "x64"
       ],
@@ -2283,9 +2283,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-win32-ia32-msvc": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-bbTE4DY+iyoO5rZ+3/L6+MrOjDJD7hnzP4ozlw8tRMobQKDpBNUWP4q97PjM8Pu6pJIqmRg9Emn2cyir+9l0sw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.2.0.tgz",
+      "integrity": "sha512-hzstTJnLf7Wt3EH1FlbhRs7OKivLzHY6457w7zXsRudUXQ73VBuVUKZLT/VUgPyl2WhQhgkYCYGRIQPoUW2TAQ==",
       "cpu": [
         "ia32"
       ],
@@ -2298,9 +2298,9 @@
       }
     },
     "node_modules/evervault-attestation-bindings-win32-x64-msvc": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-vAkh1zy4tgMbxaQJjHEAS0Phl4VY+Bcrl8h61sOnMBh5rZ1mpWNxG1Va2WYlXptN2HnB3KdtzZLOEInfOJ8seA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.2.0.tgz",
+      "integrity": "sha512-7fDGTnEz3qP0+412vm3T6WCY9mrKTc8AUQW30doWB7U0PgZ23mzxhUpQyaqvolkVsNiQcLR5vccLjSw+l74FBg==",
       "cpu": [
         "x64"
       ],
@@ -7276,95 +7276,95 @@
       "version": "2.0.3"
     },
     "evervault-attestation-bindings": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-/H9yyW7WY2XXIdIUGAAu6GIFuhmM+q/m+RcPO2j13KwaqmiDT3hzMiY3C8SP1refEr1oANy+l1wsEgSo+VbUpg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings/-/evervault-attestation-bindings-0.2.0.tgz",
+      "integrity": "sha512-PUVaekI6EhiI3KONaZSt6X4xu2S9n3s/l04ZXuOvm3cXbPnO4boyFWDL6TkZ3cUK/6LtD0f19MgfT+fpm+qpuw==",
       "optional": true,
       "requires": {
-        "evervault-attestation-bindings-android-arm-eabi": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-android-arm64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-arm64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-universal": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-darwin-x64": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm64-gnu": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-arm64-musl": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-x64-gnu": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-linux-x64-musl": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-win32-ia32-msvc": "0.1.0-alpha.3",
-        "evervault-attestation-bindings-win32-x64-msvc": "0.1.0-alpha.3"
+        "evervault-attestation-bindings-android-arm-eabi": "0.2.0",
+        "evervault-attestation-bindings-android-arm64": "0.2.0",
+        "evervault-attestation-bindings-darwin-arm64": "0.2.0",
+        "evervault-attestation-bindings-darwin-universal": "0.2.0",
+        "evervault-attestation-bindings-darwin-x64": "0.2.0",
+        "evervault-attestation-bindings-linux-arm-gnueabihf": "0.2.0",
+        "evervault-attestation-bindings-linux-arm64-gnu": "0.2.0",
+        "evervault-attestation-bindings-linux-arm64-musl": "0.2.0",
+        "evervault-attestation-bindings-linux-x64-gnu": "0.2.0",
+        "evervault-attestation-bindings-linux-x64-musl": "0.2.0",
+        "evervault-attestation-bindings-win32-ia32-msvc": "0.2.0",
+        "evervault-attestation-bindings-win32-x64-msvc": "0.2.0"
       }
     },
     "evervault-attestation-bindings-android-arm-eabi": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-OCAyKcXNiwl2glBFudxMhTCLPa52cL7PH9BsfR5NcyF1PjiiWqSLACDqBiRcihrCkbnOm4FD74q+8Vt8jILD5Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm-eabi/-/evervault-attestation-bindings-android-arm-eabi-0.2.0.tgz",
+      "integrity": "sha512-LOT8nW8J7n8BOwaJvaHJaDT1R/r6f2OkOL1z8hqXhj5sGYPD6xY0kuA7NNDeCx17YKjLrbySDpJSH9Gl8q25YQ==",
       "optional": true
     },
     "evervault-attestation-bindings-android-arm64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-C6scS1nyekml+7PVkhCeFcYVdi6TPgeOmrzXKpuo26puk9YFHUE6nbvWRwJSkTNLvdSWEcNkr4rU3IDspZ8mWQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-android-arm64/-/evervault-attestation-bindings-android-arm64-0.2.0.tgz",
+      "integrity": "sha512-w7s3uXr+8ZLRUhWxM4c0dzOfBYOxzpSCH/UF6Tp/VmBOZcsLNDcK34uz8V9HwCu2cyAE0ibelG2sPAPxVgc9OQ==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-arm64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-LmDX/RDP3OiWOd87YzGWwJxSc+g0g+ecqIk7XBUIfk8VCt15GiGmDhoieG7inCuDZDAMlo5G+kK3uR+pzajbYw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-arm64/-/evervault-attestation-bindings-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-n6DPLVlCKs0usArLhVKokyKP09VkratM/xgjuUKMKHLYfUFOd+YT7TDnqcbD4T8rNZ4KtyDe8CNcDkAF55ecYA==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-universal": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-74fDH5CZsxOr4OAUHmjRDUstkzuool19IsAW7jeYg9OcQVpaSZOylNoiciwzQM0SA0QezSDtEtj+Fr0BxMDm9A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-universal/-/evervault-attestation-bindings-darwin-universal-0.2.0.tgz",
+      "integrity": "sha512-CFm4Cp3uX9oIIs9uYmI2V/sUtXSNq20VR1qe/n5EZhrFrCTxgEwE4k+Xd8TY+pgYtL2DtP5NzdiLgaPf4Dd2wQ==",
       "optional": true
     },
     "evervault-attestation-bindings-darwin-x64": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-VK4Zmh+TteoAwHjNSahCzpzsUjzECZLNp/gg99guMbwowScTqxApD1T8uaOyiVT1NT+tP8vSiAfKCVAt7EekUQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-darwin-x64/-/evervault-attestation-bindings-darwin-x64-0.2.0.tgz",
+      "integrity": "sha512-/xBdmtgTTgU2vVFrd1xR/vieyd069Z4h4AY85MpzdXMnc4PB8csp4rMaKNgtWI4DNrqqU6gK5WmODlYlmPUw6A==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm-gnueabihf": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-DPJmR/bX8o5Sfr63cUR+4seV0yDT5iA8djlL2Jnn2RFucqWZQeLuXmLdVJZAFAdvdRUB1/JVp3LYi0Pvq0jpLg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm-gnueabihf/-/evervault-attestation-bindings-linux-arm-gnueabihf-0.2.0.tgz",
+      "integrity": "sha512-yIpagNqQuDFaoyqn46tj1LdxhC0LFPfiJxCx58jKZlWIVaTRQGD1hzJN2Hs9MSdt8zW0DCDmsNqMA2XhBJnH4A==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm64-gnu": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-zLts95/tYFWa+ttdPxY+8ZKhknSM7uTKZ11bmLjqxv+3yPnw11H/YbPMJ6cf/OhHEBNTPINK0gJwx9gUPnP1fg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-gnu/-/evervault-attestation-bindings-linux-arm64-gnu-0.2.0.tgz",
+      "integrity": "sha512-P4ATWOgp7PW06BuXmNVX/hhZZ/Wf/W2Ek+l1Yh/cly6UH3O00h9tSP6kCIEvbMU1D2YaGky3uP8YCNzm0SGXsg==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-arm64-musl": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-zv+70+YD5r4KPqVTxbjoDJcz2wPedtjVYSZLwm0rKotT6opxTWpxv17y35Jy6Q/nNcZuboMh2W8tkPsxehrvIQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-arm64-musl/-/evervault-attestation-bindings-linux-arm64-musl-0.2.0.tgz",
+      "integrity": "sha512-Aw0FGQ1U55AhICYlnyLPeGwEIRmLVaHqZRtoNhwPFYlkkQu+RNBUi+0mLhGLrJ8/CPkPy5o4XJuUByDs7iVWog==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-x64-gnu": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-w3VPXTgFpSI14vfRzXXIl2JV0iZGcKoM9dI5AVM5fRwR+9RLjoBL0eur8U3Of0EMxT6dHNT4E+qQhVUiZAgYuA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-gnu/-/evervault-attestation-bindings-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-6P1P+oy/Z3tW+FA485DCp6fKMDY68aP+HGCMk8bS231uziWqJw03d9PaetjXWda1oZFpt1pJrAFlsrl7ahTd/Q==",
       "optional": true
     },
     "evervault-attestation-bindings-linux-x64-musl": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-Z6K66TLN9BVYY6sTVmEWaRKKEAOTVdl0AxWh7MdpkGrNdD2Y4awLiaJiYX0nwkxllUhkkEGKlAQGq2zvrNJwtw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-linux-x64-musl/-/evervault-attestation-bindings-linux-x64-musl-0.2.0.tgz",
+      "integrity": "sha512-1lDtFUBDf9khE5IxYojQyBnvPZ5D8PfSxNECSm0GnoTyrnQhPTgEvzxk8lorbTfivaehD/x6RnjjDudI2EVVFQ==",
       "optional": true
     },
     "evervault-attestation-bindings-win32-ia32-msvc": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-bbTE4DY+iyoO5rZ+3/L6+MrOjDJD7hnzP4ozlw8tRMobQKDpBNUWP4q97PjM8Pu6pJIqmRg9Emn2cyir+9l0sw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-ia32-msvc/-/evervault-attestation-bindings-win32-ia32-msvc-0.2.0.tgz",
+      "integrity": "sha512-hzstTJnLf7Wt3EH1FlbhRs7OKivLzHY6457w7zXsRudUXQ73VBuVUKZLT/VUgPyl2WhQhgkYCYGRIQPoUW2TAQ==",
       "optional": true
     },
     "evervault-attestation-bindings-win32-x64-msvc": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-vAkh1zy4tgMbxaQJjHEAS0Phl4VY+Bcrl8h61sOnMBh5rZ1mpWNxG1Va2WYlXptN2HnB3KdtzZLOEInfOJ8seA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/evervault-attestation-bindings-win32-x64-msvc/-/evervault-attestation-bindings-win32-x64-msvc-0.2.0.tgz",
+      "integrity": "sha512-7fDGTnEz3qP0+412vm3T6WCY9mrKTc8AUQW30doWB7U0PgZ23mzxhUpQyaqvolkVsNiQcLR5vccLjSw+l74FBg==",
       "optional": true
     },
     "execa": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     }
   },
   "optionalDependencies": {
-    "evervault-attestation-bindings": "^0.1.0-alpha.3"
+    "evervault-attestation-bindings": "^0.2.0"
   }
 }


### PR DESCRIPTION
# Why
User's may want to re-deploy their Cage with different PCRs, or signed with a different cert. This would allow users to attempt to attest their Cage using the old set of PCRs and the new set of PCRs. This would allow their client to keep making successful connections during a deployment.

# How
* Bump version of node attestation bindings used
* Coerce data given by user into an array, and pass that into the attestation bindings

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
