### PR TITLE
docs(cages attestation): document changes which allow users to provide a list of sets of PCRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ async evervault.enableOutboundRelay([options: Object])
 async evervault.enableCagesBeta([cageAttestationData: Object])
 ```
 
-| Key          | Type     | Default     | Description                                                                                                                                               |
-| ------------ | -------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<CageName>` | `Object` | `undefined` | Requests to a Cage specified in this object will include a check to verify that the PCRs provided in the object are included in the attestation document. |
+| Key          | Type             | Default     | Description                                                                                                                                               |
+| ------------ | ---------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<CageName>` | `Object` `Array` | `undefined` | Requests to a Cage specified in this object will include a check to verify that the PCRs provided in the object are included in the attestation document. The provided data can be either a single Object, or an Array of Objects to allow roll-over between different sets of PCRs. |
 
 #### Cages Beta Example
 


### PR DESCRIPTION
# Why
We made updates to the Node SDK to allow users to use a list of sets of PCRs when attesting their Cage (https://github.com/evervault/evervault-node/pull/120) 

# How
Add info about change

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
