### PR TITLE
fix(cageattestation): correct attested tls connection behaviour

### DIFF
--- a/lib/utils/cageAttest.js
+++ b/lib/utils/cageAttest.js
@@ -40,7 +40,9 @@ function attestCageConnection(hostname, cert, cagesAttestationInfo = {}) {
   try {
     if (!hasAttestationBindings()) {
       throw new CageAttestationError(
-        'Cage attestation bindings have not been installed.'
+        'Cage attestation bindings have not been installed.',
+        hostname,
+        cert
       );
     }
     // Pull cage name from cage hostname
@@ -61,14 +63,18 @@ function attestCageConnection(hostname, cert, cagesAttestationInfo = {}) {
       console.warn(
         `EVERVAULT WARN :: Connection to Cage ${cageName} failed attestation`
       );
-      throw new CageAttestationError(`Attestation to ${cageName} failed`);
+      throw new CageAttestationError(
+        `Attestation to ${cageName} failed`,
+        hostname,
+        cert
+      );
     }
   } catch (err) {
     console.error(
       `EVERVAULT ERROR :: An unexpected error occurred while attempting to attest a connection to your Cage`,
       err.message
     );
-    throw err;
+    return err;
   }
 }
 
@@ -76,7 +82,15 @@ function addAttestationListener(config, cagesAttestationInfo) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
     if (hostname.endsWith(config.cagesHostname)) {
-      attestCageConnection(hostname, cert, cagesAttestationInfo);
+      // we expect undefined when attestation is successful, else an error
+      const attestationResult = attestCageConnection(
+        hostname,
+        cert,
+        cagesAttestationInfo
+      );
+      if (attestationResult != null) {
+        return attestationResult;
+      }
     }
     // always perform base checks
     return origCheckServerIdentity(hostname, cert);

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -23,7 +23,13 @@ class DecryptError extends EvervaultError {}
 
 class RelayOutboundConfigError extends EvervaultError {}
 
-class CageAttestationError extends EvervaultError {}
+class CageAttestationError extends EvervaultError {
+  constructor(reason, host, cert) {
+    super(reason);
+    this.host = host;
+    this.cert = cert;
+  }
+}
 
 class ExceededMaxFileSizeError extends EvervaultError {}
 


### PR DESCRIPTION
# Why

If incorrect PCRs were provided to the Cage attestation client, the resulting error could not be caught. This was due to the error being thrown within the `checkServerIdentity` override, where it should have been returned.

# How

Update error shape to match node spec. Return error instead of throwing.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
