### PR TITLE
fix(cageattest): split out require of attestation bindings

### DIFF
--- a/lib/utils/cageAttest.js
+++ b/lib/utils/cageAttest.js
@@ -4,15 +4,18 @@ const tls = require('tls');
 const origCreateSecureContext = tls.createSecureContext;
 const origCheckServerIdentity = tls.checkServerIdentity;
 
-let attestationBindings;
+const attestationBindings = loadAttestationBindings();
+
+function loadAttestationBindings() {
+  try {
+    return require('evervault-attestation-bindings');
+  } catch (_) {
+    return null;
+  }
+}
 
 function hasAttestationBindings() {
-  try {
-    attestationBindings = require('evervault-attestation-bindings');
-    return true;
-  } catch (_) {
-    return false;
-  }
+  return attestationBindings != null;
 }
 
 async function trustCagesRootCA(evClient) {


### PR DESCRIPTION
# Why

Attestation bindings were required on hot code paths, which is unnecessary. We can require them at the top level, and then check that the bindings are not null on hot paths.

# How

Load attestation bindings at top level.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
