### PR TITLE
feat: adding retries to getting apps key

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -42,11 +42,14 @@ module.exports = (appUuid, apiKey, config) => {
   ) => request('POST', path, headers, data, basicAuth, parse);
 
   const getCageKey = async () => {
-    const response = await get('cages/key').catch((_e) => {
-      throw new errors.CageKeyError(
-        "An error occurred while retrieving the cage's key"
-      );
-    });
+    const getCagesKeyCallback = async () => {
+      return await get('cages/key', {}, true).catch((_e) => {
+        throw new errors.CageKeyError(
+          "An error occurred while retrieving the cage's key"
+        );
+      });
+    };
+    const response = await makeGetRequestWithRetry(getCagesKeyCallback);
     if (response.statusCode >= 200 && response.statusCode < 300) {
       return response.body;
     }
@@ -182,6 +185,29 @@ module.exports = (appUuid, apiKey, config) => {
     }
     throw errors.mapApiResponseToError(response);
   };
+
+  async function makeGetRequestWithRetry(
+    requestCallback,
+    maxRetries = 3,
+    retryDelay = 250
+  ) {
+    let retryCount = 0;
+    let retryDelayMs = retryDelay;
+    let error = null;
+    while (retryCount < maxRetries) {
+      try {
+        return await requestCallback();
+      } catch (e) {
+        console.error(`Attempt ${retryCount + 1} failed: ${e.message}`);
+        retryCount++;
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        retryDelayMs *= 2;
+        error = e;
+      }
+    }
+
+    throw error;
+  }
 
   return {
     getCageKey,


### PR DESCRIPTION
# Why
From a serverless function the SDK is receiving 502's from the CDN when retrieving the App's public key.

# How

- Add a function to retry a max of 3 times, each time double the time between requests.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
