### PR TITLE
Fix typescript interface for `enableCagesBeta` in evervault.d.ts

### DIFF
--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -6,6 +6,6 @@ declare module "@evervault/sdk" {
         run: <T>(functionName: string, data: object, options?: { async?: boolean, version?: string }) => Promise<{ result: T, runId: string, appUuid: string }>;
         createRunToken: (functionName: string, data: object) => Promise<{ token: string }>;
         enableOutboundRelay: (options: { decryptionDomains: string[], debugRequests: boolean }) => Promise<void>;
-        enableCagesBeta: (cageAttestationData: Record<string, { pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string } | [ {pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string }]>) => Promise<void>;
+        enableCagesBeta: (cageAttestationData: Record<string, { pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string } | {pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string }[]>) => Promise<void>;
     }
 }

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -6,6 +6,6 @@ declare module "@evervault/sdk" {
         run: <T>(functionName: string, data: object, options?: { async?: boolean, version?: string }) => Promise<{ result: T, runId: string, appUuid: string }>;
         createRunToken: (functionName: string, data: object) => Promise<{ token: string }>;
         enableOutboundRelay: (options: { decryptionDomains: string[], debugRequests: boolean }) => Promise<void>;
-        enableCagesBeta: (cageAttestationData: Record<string, { pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string }>) => Promise<void>;
+        enableCagesBeta: (cageAttestationData: Record<string, { pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string } | [ {pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string }]>) => Promise<void>;
     }
 }


### PR DESCRIPTION
Update  interface for enableCagesBeta in `evervault.d.ts` so that you can pass an array of PCR document objects, or just a single one

# Why
* `lib/utils/cageAttest.js:55-60` (`function attestCageConnection(hostname, cert, cagesAttestationInfo = {}){...}`) handles the PCR document passed in to the `enableCagesBeta` function. 
* if only a single set of PCRs is passed in for a cage, the object containing the set of PCRs is wrapped in an array. If an array of PCRs is passed it, no change is made. 
* This means that for a given cage, either a single object containing PCRs can be passed in to `enableCagesBeta`, or an array of objects containing PCRs may be passed in. 
* **However**, the typescript interface in `evervault.d.ts` defines an interface that does not allow for an array of objects containing PCRs to be passed in. 
* _therefore, trying to pass in an array of objects containing PCRs for a given cage to the `enableCagesBeta` function results in a typescript compilation error, even though doing so is valid_. A user trying to pass in multiple such documents must use `@ts-ignore` to bypass the typescript error.

# How

This PR updates the typescript interface so that it is not necessary to use `@ts-ignore` to ignore typescript compiler errors when trying to pass in an array of objects containing PCRs

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
