### PR TITLE
chore(e2e_tests): Add e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,3 +37,4 @@ jobs:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
           EV_FUNCTION_NAME: ${{ secrets.EV_FUNCTION_NAME }}
+          EV_SYNTHETIC_ENDPOINT_URL: ${{ secrets.EV_SYNTHETIC_ENDPOINT_URL }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+name: Run Node.js SDK E2E Tests
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [12, 14, 16, 18]
+        os: [ubuntu-latest]
+        include:
+          - perform-attestation: false
+          - perform-attestation: true
+            node-version: 18
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run lint
+      - run: npm run test:e2e
+        env:
+          EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
+          EV_API_KEY: ${{ secrets.EV_API_KEY }}
+          EV_FUNCTION_NAME: ${{ secrets.EV_FUNCTION_NAME }}

--- a/e2e/encryptDecrypt.test.js
+++ b/e2e/encryptDecrypt.test.js
@@ -1,71 +1,71 @@
 const { expect } = require('chai');
-const Evervault = require('../lib');;
+const Evervault = require('../lib');
 
-describe("Encrypt and Decrypt", () => {
-    const appUuid = process.env.EV_APP_UUID;
-    const apiKey = process.env.EV_API_KEY;
+describe('Encrypt and Decrypt', () => {
+  const appUuid = process.env.EV_APP_UUID;
+  const apiKey = process.env.EV_API_KEY;
 
-    let evervaultClient;
-    
-    beforeEach(() => {
-        evervaultClient = new Evervault(appUuid, apiKey);
+  let evervaultClient;
+
+  beforeEach(() => {
+    evervaultClient = new Evervault(appUuid, apiKey);
+  });
+
+  context('Encrypt and Decrypt', () => {
+    it('encrypts boolean true', async () => {
+      const payload = true;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
     });
 
-    context('Encrypt and Decrypt', () => {
-        it("encrypts boolean true", async () => {
-            const payload = true;
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.equal(decrypted);
-        });
-
-        it('Encrypt boolean false', async () => {
-            const payload = false;
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.equal(decrypted);
-        });
-
-        it('Encrypt string', async () => {
-            const payload = "hello world";
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.equal(decrypted);
-        });
-
-        it('Encrypt integer', async () => {
-            const payload = 1;
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.equal(decrypted);
-        });
-
-        it('Encrypt float', async () => {
-            const payload = 1.5;
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.equal(decrypted);
-        });
-
-        it('Encrypt array', async () => {
-            const payload = ["hello", 1, 1.5, true, false];
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.deep.equal(decrypted);
-        });
-
-        it('Encrypt object', async () => {
-            const payload = {
-                "string": "hello",
-                "integer": 1,
-                "float": 1.5,
-                "true": true,
-                "false": false,
-                "array": ["hello", 1, 1.5, true, false]
-            };
-            const encrypted = await evervaultClient.encrypt(payload);
-            const decrypted = await evervaultClient.decrypt(encrypted);
-            expect(payload).to.deep.equal(decrypted);
-        });
+    it('Encrypt boolean false', async () => {
+      const payload = false;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
     });
+
+    it('Encrypt string', async () => {
+      const payload = 'hello world';
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt integer', async () => {
+      const payload = 1;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt float', async () => {
+      const payload = 1.5;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt array', async () => {
+      const payload = ['hello', 1, 1.5, true, false];
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.deep.equal(decrypted);
+    });
+
+    it('Encrypt object', async () => {
+      const payload = {
+        string: 'hello',
+        integer: 1,
+        float: 1.5,
+        true: true,
+        false: false,
+        array: ['hello', 1, 1.5, true, false],
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.deep.equal(decrypted);
+    });
+  });
 });

--- a/e2e/encryptDecrypt.test.js
+++ b/e2e/encryptDecrypt.test.js
@@ -7,11 +7,73 @@ describe('Encrypt and Decrypt', () => {
 
   let evervaultClient;
 
-  beforeEach(() => {
-    evervaultClient = new Evervault(appUuid, apiKey);
+  context('Encrypt and Decrypt with K1 curve', () => {
+    beforeEach(() => {
+      evervaultClient = new Evervault(appUuid, apiKey);
+    });
+
+    it('encrypts boolean true', async () => {
+      const payload = true;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt boolean false', async () => {
+      const payload = false;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt string', async () => {
+      const payload = 'hello world';
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt integer', async () => {
+      const payload = 1;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt float', async () => {
+      const payload = 1.5;
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.equal(decrypted);
+    });
+
+    it('Encrypt array', async () => {
+      const payload = ['hello', 1, 1.5, true, false];
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.deep.equal(decrypted);
+    });
+
+    it('Encrypt object', async () => {
+      const payload = {
+        string: 'hello',
+        integer: 1,
+        float: 1.5,
+        true: true,
+        false: false,
+        array: ['hello', 1, 1.5, true, false],
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.deep.equal(decrypted);
+    });
   });
 
-  context('Encrypt and Decrypt', () => {
+  context('Encrypt and Decrypt with R1 curve', () => {
+    beforeEach(() => {
+      evervaultClient = new Evervault(appUuid, apiKey, { curve: 'prime256v1' });
+    });
+
     it('encrypts boolean true', async () => {
       const payload = true;
       const encrypted = await evervaultClient.encrypt(payload);

--- a/e2e/encryptDecrypt.test.js
+++ b/e2e/encryptDecrypt.test.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai');
+const Evervault = require('../lib');;
+
+describe("Encrypt and Decrypt", () => {
+    const appUuid = process.env.EV_APP_UUID;
+    const apiKey = process.env.EV_API_KEY;
+
+    let evervaultClient;
+    
+    beforeEach(() => {
+        evervaultClient = new Evervault(appUuid, apiKey);
+    });
+
+    context('Encrypt and Decrypt', () => {
+        it("encrypts boolean true", async () => {
+            const payload = true;
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.equal(decrypted);
+        });
+
+        it('Encrypt boolean false', async () => {
+            const payload = false;
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.equal(decrypted);
+        });
+
+        it('Encrypt string', async () => {
+            const payload = "hello world";
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.equal(decrypted);
+        });
+
+        it('Encrypt integer', async () => {
+            const payload = 1;
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.equal(decrypted);
+        });
+
+        it('Encrypt float', async () => {
+            const payload = 1.5;
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.equal(decrypted);
+        });
+
+        it('Encrypt array', async () => {
+            const payload = ["hello", 1, 1.5, true, false];
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.deep.equal(decrypted);
+        });
+
+        it('Encrypt object', async () => {
+            const payload = {
+                "string": "hello",
+                "integer": 1,
+                "float": 1.5,
+                "true": true,
+                "false": false,
+                "array": ["hello", 1, 1.5, true, false]
+            };
+            const encrypted = await evervaultClient.encrypt(payload);
+            const decrypted = await evervaultClient.decrypt(encrypted);
+            expect(payload).to.deep.equal(decrypted);
+        });
+    });
+});

--- a/e2e/function.test.js
+++ b/e2e/function.test.js
@@ -2,61 +2,71 @@ const { expect } = require('chai');
 const axios = require('axios');
 const Evervault = require('../lib');
 
-describe("Encrypt and Decrypt", () => {
-    const appUuid = process.env.EV_APP_UUID;
-    const apiKey = process.env.EV_API_KEY;
-    const functionName = process.env.EV_FUNCTION_NAME;
+describe('Encrypt and Decrypt', () => {
+  const appUuid = process.env.EV_APP_UUID;
+  const apiKey = process.env.EV_API_KEY;
+  const functionName = process.env.EV_FUNCTION_NAME;
 
-    let evervaultClient;
-    
-    beforeEach(() => {
-        evervaultClient = new Evervault(appUuid, apiKey);
+  let evervaultClient;
+
+  beforeEach(() => {
+    evervaultClient = new Evervault(appUuid, apiKey);
+  });
+
+  context('Function runs', () => {
+    it('runs the function', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+
+      const functionResponse = await evervaultClient.run(
+        functionName,
+        encrypted
+      );
+      expect(functionResponse.result.message).to.equal('OK');
     });
 
-    context('Function runs', () => {
-        it("runs the function", async () => {
-            const payload = {
-                "name": "John Doe",
-                "age": 42,
-                "isAlive": true
-            };
-            const encrypted = await evervaultClient.encrypt(payload);
+    it('runs the function async', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
 
-            const functionResponse = await evervaultClient.run(functionName, encrypted)
-            expect(functionResponse.result.message).to.equal("OK");
-        });
-
-        it("runs the function async", async () => {
-            const payload = {
-                "name": "John Doe",
-                "age": 42,
-                "isAlive": true
-            };
-            const encrypted = await evervaultClient.encrypt(payload);
-
-            const functionResponse = await evervaultClient.run(functionName, encrypted, { async: true });
-            expect(functionResponse.length).to.equal(0)
-        });
-
-        it("runs the function witih a run token", async () => {
-            const payload = {
-                "name": "John Doe",
-                "age": 42,
-                "isAlive": true
-            };
-            const encrypted = await evervaultClient.encrypt(payload);
-            const tokenResponse = await evervaultClient.createRunToken(functionName, encrypted);
-            const functionResponse = await axios.post(
-                `https://run.evervault.com/${functionName}`,
-                { ...encrypted },
-                {
-                    headers: {
-                        "Authorization": `Bearer ${tokenResponse.token}`,
-                        "Content-Type": "application/json",
-                    }
-                }
-            );
-            expect(functionResponse.data.result.message).to.equal("OK");
-        });
+      const functionResponse = await evervaultClient.run(
+        functionName,
+        encrypted,
+        { async: true }
+      );
+      expect(functionResponse.length).to.equal(0);
     });
+
+    it('runs the function witih a run token', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+      const tokenResponse = await evervaultClient.createRunToken(
+        functionName,
+        encrypted
+      );
+      const functionResponse = await axios.post(
+        `https://run.evervault.com/${functionName}`,
+        { ...encrypted },
+        {
+          headers: {
+            Authorization: `Bearer ${tokenResponse.token}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      expect(functionResponse.data.result.message).to.equal('OK');
+    });
+  });
 });

--- a/e2e/function.test.js
+++ b/e2e/function.test.js
@@ -2,49 +2,71 @@ const { expect } = require('chai');
 const axios = require('axios');
 const Evervault = require('../lib');
 
-describe("Encrypt and Decrypt", () => {
-    const appUuid = process.env.EV_APP_UUID;
-    const apiKey = process.env.EV_API_KEY;
-    const functionName = process.env.EV_FUNCTION_NAME;
+describe('Encrypt and Decrypt', () => {
+  const appUuid = process.env.EV_APP_UUID;
+  const apiKey = process.env.EV_API_KEY;
+  const functionName = process.env.EV_FUNCTION_NAME;
 
-    let evervaultClient;
-    
-    beforeEach(() => {
-        evervaultClient = new Evervault(appUuid, apiKey);
+  let evervaultClient;
+
+  beforeEach(() => {
+    evervaultClient = new Evervault(appUuid, apiKey);
+  });
+
+  context('Function runs', () => {
+    it('runs the function', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+
+      const functionResponse = await evervaultClient.run(
+        functionName,
+        encrypted
+      );
+      expect(functionResponse.result.message).to.equal('OK');
     });
 
-    context('Function runs', () => {
-        it("runs the function", async () => {
-            const payload = {"name": "test"};
-            const encrypted = await evervaultClient.encrypt(payload);
+    it('runs the function async', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
 
-            const functionResponse = await evervaultClient.run(functionName, encrypted)
-            expect(functionResponse.result.message).to.equal("Hello from a Function! It seems you have 4 letters in your name");
-        });
-
-        it("runs the function async", async () => {
-            const payload = {"name": "test"};
-            const encrypted = await evervaultClient.encrypt(payload);
-
-            const functionResponse = await evervaultClient.run(functionName, encrypted, { async: true });
-            expect(functionResponse.length).to.equal(0)
-        });
-
-        it("runs the function witih a run token", async () => {
-            const payload = {"name": "test"};
-            const encrypted = await evervaultClient.encrypt(payload);
-            const tokenResponse = await evervaultClient.createRunToken(functionName, encrypted);
-            const functionResponse = await axios.post(
-                `https://run.evervault.com/${functionName}`,
-                { ...encrypted },
-                {
-                    headers: {
-                        "Authorization": `Bearer ${tokenResponse.token}`,
-                        "Content-Type": "application/json",
-                    }
-                }
-            );
-            expect(functionResponse.data.result.message).to.equal("Hello from a Function! It seems you have 4 letters in your name");
-        });
+      const functionResponse = await evervaultClient.run(
+        functionName,
+        encrypted,
+        { async: true }
+      );
+      expect(functionResponse.length).to.equal(0);
     });
+
+    it('runs the function witih a run token', async () => {
+      const payload = {
+        name: 'John Doe',
+        age: 42,
+        isAlive: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+      const tokenResponse = await evervaultClient.createRunToken(
+        functionName,
+        encrypted
+      );
+      const functionResponse = await axios.post(
+        `https://run.evervault.com/${functionName}`,
+        { ...encrypted },
+        {
+          headers: {
+            Authorization: `Bearer ${tokenResponse.token}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      expect(functionResponse.data.result.message).to.equal('OK');
+    });
+  });
 });

--- a/e2e/function.test.js
+++ b/e2e/function.test.js
@@ -2,71 +2,49 @@ const { expect } = require('chai');
 const axios = require('axios');
 const Evervault = require('../lib');
 
-describe('Encrypt and Decrypt', () => {
-  const appUuid = process.env.EV_APP_UUID;
-  const apiKey = process.env.EV_API_KEY;
-  const functionName = process.env.EV_FUNCTION_NAME;
+describe("Encrypt and Decrypt", () => {
+    const appUuid = process.env.EV_APP_UUID;
+    const apiKey = process.env.EV_API_KEY;
+    const functionName = process.env.EV_FUNCTION_NAME;
 
-  let evervaultClient;
-
-  beforeEach(() => {
-    evervaultClient = new Evervault(appUuid, apiKey);
-  });
-
-  context('Function runs', () => {
-    it('runs the function', async () => {
-      const payload = {
-        name: 'John Doe',
-        age: 42,
-        isAlive: true,
-      };
-      const encrypted = await evervaultClient.encrypt(payload);
-
-      const functionResponse = await evervaultClient.run(
-        functionName,
-        encrypted
-      );
-      expect(functionResponse.result.message).to.equal('OK');
+    let evervaultClient;
+    
+    beforeEach(() => {
+        evervaultClient = new Evervault(appUuid, apiKey);
     });
 
-    it('runs the function async', async () => {
-      const payload = {
-        name: 'John Doe',
-        age: 42,
-        isAlive: true,
-      };
-      const encrypted = await evervaultClient.encrypt(payload);
+    context('Function runs', () => {
+        it("runs the function", async () => {
+            const payload = {"name": "test"};
+            const encrypted = await evervaultClient.encrypt(payload);
 
-      const functionResponse = await evervaultClient.run(
-        functionName,
-        encrypted,
-        { async: true }
-      );
-      expect(functionResponse.length).to.equal(0);
-    });
+            const functionResponse = await evervaultClient.run(functionName, encrypted)
+            expect(functionResponse.result.message).to.equal("Hello from a Function! It seems you have 4 letters in your name");
+        });
 
-    it('runs the function witih a run token', async () => {
-      const payload = {
-        name: 'John Doe',
-        age: 42,
-        isAlive: true,
-      };
-      const encrypted = await evervaultClient.encrypt(payload);
-      const tokenResponse = await evervaultClient.createRunToken(
-        functionName,
-        encrypted
-      );
-      const functionResponse = await axios.post(
-        `https://run.evervault.com/${functionName}`,
-        { ...encrypted },
-        {
-          headers: {
-            Authorization: `Bearer ${tokenResponse.token}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-      expect(functionResponse.data.result.message).to.equal('OK');
+        it("runs the function async", async () => {
+            const payload = {"name": "test"};
+            const encrypted = await evervaultClient.encrypt(payload);
+
+            const functionResponse = await evervaultClient.run(functionName, encrypted, { async: true });
+            expect(functionResponse.length).to.equal(0)
+        });
+
+        it("runs the function witih a run token", async () => {
+            const payload = {"name": "test"};
+            const encrypted = await evervaultClient.encrypt(payload);
+            const tokenResponse = await evervaultClient.createRunToken(functionName, encrypted);
+            const functionResponse = await axios.post(
+                `https://run.evervault.com/${functionName}`,
+                { ...encrypted },
+                {
+                    headers: {
+                        "Authorization": `Bearer ${tokenResponse.token}`,
+                        "Content-Type": "application/json",
+                    }
+                }
+            );
+            expect(functionResponse.data.result.message).to.equal("Hello from a Function! It seems you have 4 letters in your name");
+        });
     });
-  });
 });

--- a/e2e/function.test.js
+++ b/e2e/function.test.js
@@ -1,0 +1,62 @@
+const { expect } = require('chai');
+const axios = require('axios');
+const Evervault = require('../lib');
+
+describe("Encrypt and Decrypt", () => {
+    const appUuid = process.env.EV_APP_UUID;
+    const apiKey = process.env.EV_API_KEY;
+    const functionName = process.env.EV_FUNCTION_NAME;
+
+    let evervaultClient;
+    
+    beforeEach(() => {
+        evervaultClient = new Evervault(appUuid, apiKey);
+    });
+
+    context('Function runs', () => {
+        it("runs the function", async () => {
+            const payload = {
+                "name": "John Doe",
+                "age": 42,
+                "isAlive": true
+            };
+            const encrypted = await evervaultClient.encrypt(payload);
+
+            const functionResponse = await evervaultClient.run(functionName, encrypted)
+            expect(functionResponse.result.message).to.equal("OK");
+        });
+
+        it("runs the function async", async () => {
+            const payload = {
+                "name": "John Doe",
+                "age": 42,
+                "isAlive": true
+            };
+            const encrypted = await evervaultClient.encrypt(payload);
+
+            const functionResponse = await evervaultClient.run(functionName, encrypted, { async: true });
+            expect(functionResponse.length).to.equal(0)
+        });
+
+        it("runs the function witih a run token", async () => {
+            const payload = {
+                "name": "John Doe",
+                "age": 42,
+                "isAlive": true
+            };
+            const encrypted = await evervaultClient.encrypt(payload);
+            const tokenResponse = await evervaultClient.createRunToken(functionName, encrypted);
+            const functionResponse = await axios.post(
+                `https://run.evervault.com/${functionName}`,
+                { ...encrypted },
+                {
+                    headers: {
+                        "Authorization": `Bearer ${tokenResponse.token}`,
+                        "Content-Type": "application/json",
+                    }
+                }
+            );
+            expect(functionResponse.data.result.message).to.equal("OK");
+        });
+    });
+});

--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -1,0 +1,33 @@
+const { expect } = require('chai');
+const Evervault = require('../lib');
+const axios = require('axios');
+
+describe("Outbound Relay Test", () => {
+    const appUuid = process.env.EV_APP_UUID;
+    const apiKey = process.env.EV_API_KEY;
+    const syntheticEndpointUrl = process.env.EV_SYNTHETIC_ENDPOINT_URL;
+
+    let evervaultClient;
+    
+    beforeEach(() => {
+        evervaultClient = new Evervault(appUuid, apiKey);
+    });
+
+    context('Enable Outbound Relay', () => {
+        it("proxies the request and decrypts the data", async () => {
+            const payload = {
+                "string": "some_string",
+                "number" : 1234567890,
+                "boolean": true
+            };
+            const encrypted = await evervaultClient.encrypt(payload);
+
+            await evervaultClient.enableOutboundRelay();
+            const response = await axios.post(syntheticEndpointUrl, encrypted);
+            const body = response.data;
+            expect(body.request.string).to.equal(false);
+            expect(body.request.number).to.equal(false);
+            expect(body.request.boolean).to.equal(false);
+        });
+    });
+});

--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -2,32 +2,32 @@ const { expect } = require('chai');
 const Evervault = require('../lib');
 const axios = require('axios');
 
-describe("Outbound Relay Test", () => {
-    const appUuid = process.env.EV_APP_UUID;
-    const apiKey = process.env.EV_API_KEY;
-    const syntheticEndpointUrl = process.env.EV_SYNTHETIC_ENDPOINT_URL;
+describe('Outbound Relay Test', () => {
+  const appUuid = process.env.EV_APP_UUID;
+  const apiKey = process.env.EV_API_KEY;
+  const syntheticEndpointUrl = process.env.EV_SYNTHETIC_ENDPOINT_URL;
 
-    let evervaultClient;
-    
-    beforeEach(() => {
-        evervaultClient = new Evervault(appUuid, apiKey);
+  let evervaultClient;
+
+  beforeEach(() => {
+    evervaultClient = new Evervault(appUuid, apiKey);
+  });
+
+  context('Enable Outbound Relay', () => {
+    it('proxies the request and decrypts the data', async () => {
+      const payload = {
+        string: 'some_string',
+        number: 1234567890,
+        boolean: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+
+      await evervaultClient.enableOutboundRelay();
+      const response = await axios.post(syntheticEndpointUrl, encrypted);
+      const body = response.data;
+      expect(body.request.string).to.equal(false);
+      expect(body.request.number).to.equal(false);
+      expect(body.request.boolean).to.equal(false);
     });
-
-    context('Enable Outbound Relay', () => {
-        it("proxies the request and decrypts the data", async () => {
-            const payload = {
-                "string": "some_string",
-                "number" : 1234567890,
-                "boolean": true
-            };
-            const encrypted = await evervaultClient.encrypt(payload);
-
-            await evervaultClient.enableOutboundRelay();
-            const response = await axios.post(syntheticEndpointUrl, encrypted);
-            const body = response.data;
-            expect(body.request.string).to.equal(false);
-            expect(body.request.number).to.equal(false);
-            expect(body.request.boolean).to.equal(false);
-        });
-    });
+  });
 });

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -22,13 +22,22 @@ module.exports = (appUuid, apiKey, config) => {
     } else {
       headers['api-key'] = apiKey;
     }
-    return phin({
-      url: path.startsWith('https://') ? path : `${config.baseUrl}/${path}`,
-      method,
-      headers,
-      data,
-      parse,
-    });
+    if (!additionalHeaders["x-async"]) {
+      return phin({
+        url: path.startsWith('https://') ? path : `${config.baseUrl}/${path}`,
+        method,
+        headers,
+        data,
+        parse,
+      });
+    } else {
+      return phin({
+        url: path.startsWith('https://') ? path : `${config.baseUrl}/${path}`,
+        method,
+        headers,
+        data
+      });
+    }
   };
 
   const get = (path, headers) => request('GET', path, headers);

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -22,7 +22,7 @@ module.exports = (appUuid, apiKey, config) => {
     } else {
       headers['api-key'] = apiKey;
     }
-    if (!additionalHeaders["x-async"]) {
+    if (!additionalHeaders['x-async']) {
       return phin({
         url: path.startsWith('https://') ? path : `${config.baseUrl}/${path}`,
         method,
@@ -35,7 +35,7 @@ module.exports = (appUuid, apiKey, config) => {
         url: path.startsWith('https://') ? path : `${config.baseUrl}/${path}`,
         method,
         headers,
-        data
+        data,
       });
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "agent-base": "^6.0.2",
         "async-retry": "^1.3.3",
+        "axios": "^1.5.0",
         "crc-32": "^1.2.2",
         "phin": "^3.5.0",
         "uasn1": "^0.7.1",
@@ -1034,12 +1035,27 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1417,6 +1433,17 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -1810,6 +1837,14 @@
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-file": {
@@ -2504,6 +2539,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -2554,6 +2608,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fromentries": {
@@ -3849,6 +3916,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "dev": true,
@@ -4732,6 +4818,11 @@
       "bin": {
         "proxy": "bin/proxy.js"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -6441,9 +6532,24 @@
         "retry": "0.13.1"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "dev": true
+    },
+    "axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -6674,6 +6780,14 @@
     "colorette": {
       "version": "1.3.0",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "7.2.0",
@@ -6941,6 +7055,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -7358,6 +7477,11 @@
       "version": "2.0.2",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -7390,6 +7514,16 @@
           "version": "3.0.0",
           "dev": true
         }
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fromentries": {
@@ -8191,6 +8325,19 @@
         "picomatch": "^2.2.3"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "dev": true
@@ -8755,6 +8902,11 @@
         "basic-auth-parser": "0.0.2",
         "debug": "^4.1.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "agent-base": "^6.0.2",
         "async-retry": "^1.3.3",
-        "axios": "^1.5.0",
         "crc-32": "^1.2.2",
         "phin": "^3.5.0",
         "uasn1": "^0.7.1",
@@ -20,6 +19,7 @@
       "devDependencies": {
         "@commitlint/cli": "^13.1.0",
         "@commitlint/config-conventional": "^13.1.0",
+        "axios": "^1.5.0",
         "chai": "^4.2.0",
         "commitizen": "^4.2.4",
         "cz-conventional-changelog": "^3.2.0",
@@ -1038,7 +1038,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1052,6 +1053,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
       "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -1438,6 +1440,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1843,6 +1846,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2543,6 +2547,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2614,6 +2619,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3920,6 +3926,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3928,6 +3935,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4822,7 +4830,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -6535,7 +6544,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -6545,6 +6555,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
       "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6785,6 +6796,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -7059,7 +7071,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -7480,7 +7493,8 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -7520,6 +7534,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8328,12 +8343,14 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -8906,7 +8923,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepare": "husky install",
     "lint": "prettier --check \"./**/*.js\"",
     "test": "mocha 'tests/**/*.test.js'",
+    "test:e2e": "mocha 'e2e/**/*.test.js' --exit",
     "test:filter": "mocha 'tests/**/*.test.js' --grep",
     "test:coverage": "nyc --reporter=text npm run test"
   },
@@ -32,6 +33,7 @@
   "dependencies": {
     "agent-base": "^6.0.2",
     "async-retry": "^1.3.3",
+    "axios": "^1.5.0",
     "crc-32": "^1.2.2",
     "phin": "^3.5.0",
     "uasn1": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "agent-base": "^6.0.2",
     "async-retry": "^1.3.3",
-    "axios": "^1.5.0",
     "crc-32": "^1.2.2",
     "phin": "^3.5.0",
     "uasn1": "^0.7.1",
@@ -42,6 +41,7 @@
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
+    "axios": "^1.5.0",
     "chai": "^4.2.0",
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.2.0",

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -190,14 +190,14 @@ describe('Testing the Evervault SDK', () => {
             },
           })
             .post(`/${cageName}`)
-            .reply(200, { result: testRunResult });
+            .reply(200, Buffer.alloc(0));
         });
 
         it('Calls the cage run api', () => {
           return sdk
             .run(cageName, testData, { async: true, version: 3 })
             .then((result) => {
-              expect(result).to.deep.equal({ result: testRunResult });
+              expect(result).to.deep.equal(Buffer.alloc(0));
               expect(runNock.isDone()).to.be.true;
             });
         });


### PR DESCRIPTION
# Why

- Developing the Node.js SDK required a lot of manual testing. Automated end-to-end tests were badly needed.

# How

This PR introduces the following changes:

- Add e2e tests to validate encryption & decryption, function runs & outbound relay proxying
- Add github workflow to automatically trigger e2e tests when pushing a change
- Fix a bug with the handling of async Function runs:
  - Async runs would return an empty `Buffer` as a response which was failing when `phin` tried to parse it as JSON


# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
