### PR TITLE
feat: add createRelayHttpsAgent to return configured https agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To make Evervault available for use in your app:
 const Evervault = require('@evervault/sdk');
 
 // Initialize the client with your App ID and API Key
-const evervaultClient = new Evervault('<API-KEY>', '<APP_ID>');
+const evervaultClient = new Evervault('<APP_ID>', '<API_KEY>');
 
 // Encrypt your sensitive data
 const encrypted = await evervaultClient.encrypt({ ssn: '012-34-5678' });
@@ -43,6 +43,12 @@ const result = await evervaultClient.run('<FUNCTION_NAME>', encrypted);
 // Send the decrypted data to a third-party API
 await evervaultClient.enableOutboundRelay();
 const response = await axios.post('https://example.com', encrypted);
+
+// Use HTTPSProxyAgent to send data to a third-party
+const httpsAgent = evervault.createRelayHttpsAgent();
+const response = await axios.get('https://example.com', { 
+  httpsAgent
+});
 
 // Decrypt the data
 const decrypted = await evervaultClient.decrypt(encrypted);
@@ -149,6 +155,22 @@ async evervault.enableOutboundRelay([options: Object])
 | ------------------- | --------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `decryptionDomains` | `Array`   | `undefined` | Requests sent to any of the domains listed will be proxied through Outbound Relay. This will override the configuration created in the Evervault dashboard. |
 | `debugRequests`     | `Boolean` | `False`     | Output request domains and whether they were sent through Outbound Relay.                                                                                   |
+
+### evervault.createRelayHttpsAgent()
+
+`evervault.createRelayHttpsAgent()` will return a `HttpsProxyAgent` configred to proxy traffic through Relay. 
+
+```javascript
+async evervault.createRelayHttpsAgent([options: Object])
+```
+#### createRelayHttpsAgent axios example
+
+```javascript
+const httpsAgent = evervault.createRelayHttpsAgent();
+const response = await axios.get('https://example.com', { 
+  httpsAgent
+});
+```
 
 ### evervault.enableCagesBeta()
 

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -1,3 +1,4 @@
+import HttpsProxyAgent from "./utils/proxyAgent";
 declare module "@evervault/sdk" {
     export default class Evervault {
         constructor(appId: string, apiKey: string)
@@ -6,7 +7,8 @@ declare module "@evervault/sdk" {
         createClientSideDecryptToken: (payload: any, expiry?: Date) => Promise<{ id: string, token: string, createdAt: Date, expiry: Date }>;
         run: <T>(functionName: string, data: object, options?: { async?: boolean, version?: string }) => Promise<{ result: T, runId: string, appUuid: string }>;
         createRunToken: (functionName: string, data: object) => Promise<{ token: string }>;
-        enableOutboundRelay: (options: { decryptionDomains: string[], debugRequests: boolean }) => Promise<void>;
+        enableOutboundRelay: (options?: { decryptionDomains: string[], debugRequests: boolean }) => Promise<void>;
         enableCagesBeta: (cageAttestationData: Record<string, { pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string } | {pcr0?: string, pcr1?: string, pcr2?: string, pcr8?: string }[]>) => Promise<void>;
+        createRelayHttpsAgent: () => HttpsProxyAgent;
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ const {
 const Config = require('./config');
 const { Crypto, Http, RelayOutboundConfig } = require('./core');
 const { TokenCreationError } = require('./utils/errors');
+const HttpsProxyAgent = require('./utils/proxyAgent');
 
 const originalRequest = https.request;
 
@@ -382,6 +383,18 @@ class EvervaultClient {
         originalRequest
       );
     }
+  }
+  /**
+   * @returns {HttpsProxyAgent}
+   */
+  createRelayHttpsAgent() {
+    return this.httpsHelper.httpsRelayAgent(
+      {
+        hostname: this.config.http.tunnelHostname,
+      },
+      this.http,
+      this.apiKey
+    );
   }
 
   defineHiddenProperty(property, value) {

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -3,24 +3,11 @@ const tls = require('tls');
 const Datatypes = require('./datatypes');
 const certHelper = require('./certHelper');
 const HttpsProxyAgent = require('./proxyAgent');
-
 const origCreateSecureContext = tls.createSecureContext;
 const EVERVAULT_DOMAINS = ['evervault.com', 'evervault.io', 'evervault.dev'];
 
-/**
- * @param {String} apiKey
- * @returns {void}
- */
-const overloadHttpsModule = async (
-  apiKey,
-  tunnelHostname,
-  domainFilter,
-  debugRequests = false,
-  evClient,
-  originalRequest
-) => {
+const certificateUtil = (evClient) => {
   let x509 = null;
-
   async function updateCertificate() {
     const pem = await evClient.getCert();
     let cert = pem.toString();
@@ -43,6 +30,24 @@ const overloadHttpsModule = async (
     );
   }
 
+  return {
+    updateCertificate,
+    isCertificateInvalid,
+  };
+};
+
+/**
+ * @param {String} apiKey
+ * @returns {void}
+ */
+const overloadHttpsModule = async (
+  apiKey,
+  tunnelHostname,
+  domainFilter,
+  debugRequests = false,
+  evClient,
+  originalRequest
+) => {
   function getDomainFromArgs(args) {
     if (typeof args[0] === 'string') {
       return new URL(args[0]).host;
@@ -76,6 +81,8 @@ const overloadHttpsModule = async (
     }
     args = args.map((arg) => {
       if (shouldProxy && arg instanceof Object) {
+        const { updateCertificate, isCertificateInvalid } =
+          certificateUtil(evClient);
         arg.agent = new HttpsProxyAgent(
           tunnelHostname,
           updateCertificate,
@@ -91,6 +98,29 @@ const overloadHttpsModule = async (
   https.request = wrapMethodRequest;
 };
 
+const httpsRelayAgent = (
+  agentConfig = { port: 443, rejectUnauthorized: true, secureProxy: true },
+  evClient,
+  apiKey
+) => {
+  const { updateCertificate, isCertificateInvalid } = certificateUtil(evClient);
+  const parsedUrl = new URL(agentConfig.hostname);
+  const agent = new HttpsProxyAgent(
+    {
+      host: parsedUrl.hostname,
+      port: parsedUrl.port || agentConfig.port,
+      secureProxy: true,
+      auth: apiKey,
+      rejectUnauthorized: agentConfig.rejectUnauthorized,
+    },
+    updateCertificate,
+    isCertificateInvalid
+  );
+
+  return agent;
+};
+
 module.exports = {
   overloadHttpsModule,
+  httpsRelayAgent,
 };

--- a/lib/utils/proxyAgent.js
+++ b/lib/utils/proxyAgent.js
@@ -101,9 +101,7 @@ class HttpsProxyAgent extends Agent {
 
     // Inject the `Proxy-Authorization` header if necessary.
     if (proxy.auth) {
-      headers['Proxy-Authorization'] = `Basic ${Buffer.from(
-        proxy.auth
-      ).toString('base64')}`;
+      headers['Proxy-Authorization'] = proxy.auth;
     }
 
     // The `Host` header should only include the port

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "agent-base": "^6.0.2",
         "async-retry": "^1.3.3",
+        "axios": "^1.5.0",
         "crc-32": "^1.2.2",
         "phin": "^3.5.0",
         "uasn1": "^0.7.1",
@@ -1034,12 +1035,27 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1417,6 +1433,17 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -1810,6 +1837,14 @@
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-file": {
@@ -2504,6 +2539,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -2554,6 +2608,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fromentries": {
@@ -3849,6 +3916,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "dev": true,
@@ -4732,6 +4818,11 @@
       "bin": {
         "proxy": "bin/proxy.js"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -6441,9 +6532,24 @@
         "retry": "0.13.1"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "dev": true
+    },
+    "axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -6674,6 +6780,14 @@
     "colorette": {
       "version": "1.3.0",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "7.2.0",
@@ -6941,6 +7055,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -7358,6 +7477,11 @@
       "version": "2.0.2",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "foreground-child": {
       "version": "2.0.0",
       "dev": true,
@@ -7390,6 +7514,16 @@
           "version": "3.0.0",
           "dev": true
         }
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fromentries": {
@@ -8191,6 +8325,19 @@
         "picomatch": "^2.2.3"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "dev": true
@@ -8755,6 +8902,11 @@
         "basic-auth-parser": "0.0.2",
         "debug": "^4.1.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "agent-base": "^6.0.2",
     "async-retry": "^1.3.3",
+    "axios": "^1.5.0",
     "crc-32": "^1.2.2",
     "phin": "^3.5.0",
     "uasn1": "^0.7.1",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const axios = require('axios');
+const Evervault = require('./lib');
+const evervault = new Evervault(
+  'app_16688a4022b0',
+  'ev:key:1:4MaKtEOgj0WVYzrGkwvUHCfkw5hozD3mdvA3dFFXVqkWMajijNa7nphCreNYXyy2O:u+IM6J:rtXyfU'
+);
+
+(async () => {
+  const httpsAgent = evervault.createRelayHttpsAgent();
+  const response = await axios.get('https://enx4th0aktbs.x.pipedream.net', {
+    httpsAgent,
+  });
+})();


### PR DESCRIPTION
# Why
When using the `enableOutboundRelay` it is currently not possible to configure Relay to send traffic to a single path on a domain. Instead all traffic will go to a configured Relay destination.

# How
- Add a new method `createRelayHttpsAgent` which will return a pre configured https agent. This agent can be passed to supporting HTTP clients to send specific requests through a Relay.

# Checklist
- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
