### PR TITLE
Removing set of github token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,4 @@ jobs:
             echo "No tag attached to HEAD. No new release needed."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Why

Error on release:

> The value of the GITHUB_TOKEN environment variable is being used for authentication.
> To have GitHub CLI store credentials instead, first clear the value from the environment.

# How

Removed set of `GITHUB_TOKEN`
