### PR TITLE
Setting npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
               }
             ' CHANGELOG.md)
             gh release create $COMMIT_TAG -t "$COMMIT_TAG" -n "$CHANGELOG"
+            echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
             npm publish
           else
             echo "No tag attached to HEAD. No new release needed."


### PR DESCRIPTION
# Why

`npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/`

# How

Added auth per [docs](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow)
