### PR TITLE
[SPE-924] Add PCR provider functionality

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,10 +5,11 @@ const DEFAULT_FUNCTION_RUN_URL = 'https://run.evervault.com';
 const DEFAULT_TUNNEL_HOSTNAME = 'https://relay.evervault.com:443';
 const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
 const DEFAULT_CAGES_CA_HOSTNAME = 'https://cages-ca.evervault.com';
-const DEFAULT_CAGES_HOSTNAME = 'cages.evervault.com';
+const DEFAULT_CAGES_HOSTNAME = 'cage.evervault.com';
 const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_MAX_FILE_SIZE_IN_MB = 25;
-const DEFAULT_ATTEST_POLL_INTERVAL = 7200;
+const DEFAULT_ATTEST_POLL_INTERVAL = 300;
+const DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 300;
 
 module.exports = () => ({
   http: {
@@ -23,6 +24,9 @@ module.exports = () => ({
     pollInterval: process.env.EV_POLL_INTERVAL || DEFAULT_POLL_INTERVAL,
     attestationDocPollInterval:
       process.env.EV_ATTEST_POLL_INTERVAL || DEFAULT_ATTEST_POLL_INTERVAL,
+    pcrProviderPollInterval:
+      process.env.EV_PCR_PROVIDER_POLL_INTERVAL ||
+      DEFAULT_PCR_PROVIDER_POLL_INTERVAL,
   },
   encryption: {
     secp256k1: {

--- a/lib/core/cageAttestationDoc.js
+++ b/lib/core/cageAttestationDoc.js
@@ -36,11 +36,10 @@ class AttestationDoc {
     }
   };
 
-  get = async (cageName) => {
+  get = (cageName) => {
     const doc = this.attestationDocCache[cageName];
     if (!doc) {
-      await this.loadCageDoc(cageName);
-      return this.attestationDocCache[cageName];
+      console.warn(`No attestation doc found for ${cageName}`);
     }
     return doc;
   };

--- a/lib/core/cagePcrManager.js
+++ b/lib/core/cagePcrManager.js
@@ -1,0 +1,121 @@
+const RepeatedTimer = require('./repeatedTimer');
+
+staticPcrsToProvider = (pcrs) => {
+  const provider = async () => {
+    return new Promise((resolve) => {
+      resolve(pcrs);
+    });
+  };
+
+  return { pcrs, provider };
+};
+
+loadPcrStore = (cageAttestationData) => {
+  var providers = {};
+  for (const [cageName, value] of Object.entries(cageAttestationData)) {
+    if (Array.isArray(value)) {
+      providers[cageName] = staticPcrsToProvider(value);
+    } else if (typeof value === 'object') {
+      providers[cageName] = staticPcrsToProvider([value]);
+    } else if (typeof value === 'function') {
+      providers[cageName] = { pcrs: [], provider: value };
+    } else {
+      console.warn(`Invalid attestation data for ${cageName}.`);
+    }
+  }
+
+  return providers;
+};
+
+class CagePcrManager {
+  constructor(config, cagesAttestationData) {
+    this.store = loadPcrStore(cagesAttestationData);
+    this.config = config;
+    this.polling = null;
+  }
+
+  disablePolling = () => {
+    if (this.polling) {
+      this.polling.stop();
+    }
+    this.polling = null;
+  };
+
+  getPollingInterval = () => {
+    if (this.polling) {
+      return this.polling.getInterval();
+    }
+    return null;
+  };
+
+  fetchPcrs = async (cageName) => {
+    const cage = this.store[cageName];
+
+    if (!cage?.provider) {
+      console.warn(
+        `PCR provider for ${cageName} is not registered. Cannot fetch PCRs.`
+      );
+      return;
+    }
+
+    try {
+      console.log(`Fetching PCRs for ${cageName}`);
+      const newPcrs = await cage.provider();
+
+      if (!newPcrs) {
+        console.warn(
+          `PCR provider for ${cageName} did not return PCRs. Cannot fetch PCRs. Using old PCRs`
+        );
+      } else {
+        cage.pcrs = newPcrs;
+      }
+
+      this.store[cageName] = cage;
+    } catch (error) {
+      console.warn(`Couldn't fetch PCRs for ${cageName}. Error: ${error}`);
+    }
+  };
+
+  get = (cageName) => {
+    const storedCageData = this.store[cageName];
+    const pcrs = storedCageData?.pcrs;
+
+    if (!pcrs) {
+      // Trigger fetching PCRs in the background
+      // checkServerIdentity is sync so can't run an async function, so we have to do this
+      // to make best effort to have the PCRs next time if they weren't available.
+      this.fetchPcrs(cageName);
+    }
+    return pcrs;
+  };
+
+  init = async () => {
+    let pollingInterval = this.config.http.pcrProviderPollInterval;
+
+    await this._getPcrs();
+
+    if (!this.polling) {
+      this.polling = RepeatedTimer(pollingInterval, this._getPcrs);
+    }
+  };
+
+  clearStoredPcrs = () => {
+    for (const [cageName, value] of Object.entries(this.store)) {
+      this.store[cageName] = { pcrs: null, provider: value.provider };
+    }
+  };
+
+  clearStore = () => {
+    this.store = {};
+  };
+
+  _getPcrs = async () => {
+    await Promise.all(
+      Object.keys(this.store).map(
+        async (cageName) => await this.fetchPcrs(cageName)
+      )
+    );
+  };
+}
+
+module.exports = CagePcrManager;

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -4,4 +4,5 @@ module.exports = {
   Labs: require('./labs'),
   RelayOutboundConfig: require('./relayOutboundConfig'),
   AttestationDoc: require('./cageAttestationDoc'),
+  CagePcrManager: require('./cagePcrManager'),
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,13 @@ const {
   cageAttest,
 } = require('./utils');
 const Config = require('./config');
-const { Crypto, Http, RelayOutboundConfig, AttestationDoc } = require('./core');
+const {
+  Crypto,
+  Http,
+  RelayOutboundConfig,
+  AttestationDoc,
+  CagePcrManager,
+} = require('./core');
 const { TokenCreationError } = require('./utils/errors');
 const console = require('console');
 const HttpsProxyAgent = require('./utils/proxyAgent');
@@ -89,17 +95,28 @@ class EvervaultClient {
 
   async enableCages(cagesAttestationData) {
     if (cageAttest.hasAttestationBindings()) {
+      //Store attestation documents from cages in cache
       let attestationCache = new AttestationDoc(
         this.config,
         this.http,
         Object.keys(cagesAttestationData),
         this.appId
       );
+
       await attestationCache.init();
+
+      //Store client PCR providers to periodically pull new PCRs
+      const cagePcrManager = new CagePcrManager(
+        this.config,
+        cagesAttestationData
+      );
+
+      await cagePcrManager.init();
+
       cageAttest.addAttestationListener(
         this.config.http,
-        cagesAttestationData,
-        attestationCache
+        attestationCache,
+        cagePcrManager
       );
     } else {
       console.error(

--- a/lib/utils/cageAttest.js
+++ b/lib/utils/cageAttest.js
@@ -84,7 +84,7 @@ function attestCageConnectionBeta(hostname, cert, cagesAttestationInfo = {}) {
   }
 }
 
-async function attestCageConnection(
+function attestCageConnection(
   hostname,
   cert,
   cagesAttestationInfo = {},
@@ -109,18 +109,8 @@ async function attestCageConnection(
       pcrsList = [pcrs];
     }
 
-    let attestationDoc = await attestationCache.get(cageName);
-    if (!attestationDoc) {
-      await attestationCache.loadCageDoc(cageName);
-      attestationDoc = await attestationCache.get(cageName);
-      if (!attestationDoc) {
-        throw new CageAttestationError(
-          "Couldn't find attestation doc in cache",
-          hostname,
-          cert
-        );
-      }
-    }
+    let attestationDoc = attestationCache.get(cageName);
+
     let attestationDocBytes = Buffer.from(attestationDoc, 'base64');
 
     let isConnectionValid = attestationBindings.attestCage(
@@ -128,17 +118,6 @@ async function attestCageConnection(
       pcrsList,
       attestationDocBytes
     );
-
-    // Reload cache to check if deployment has happened between polling
-    if (!isConnectionValid) {
-      attestationCache.loadCageDoc(cageName);
-      isConnectionValid = await getCageAttestationDoc(
-        cageName,
-        cert,
-        pcrsList,
-        attestationCache
-      );
-    }
 
     if (!isConnectionValid) {
       console.warn(
@@ -194,14 +173,14 @@ function addAttestationListenerBeta(config, cagesAttestationInfo) {
   };
 }
 
-function addAttestationListener(
-  config,
-  cagesAttestationInfo,
-  attestationCache
-) {
+function addAttestationListener(config, attestationCache, cagePcrManager) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
     if (hostname.endsWith(config.cagesHostname)) {
+      const { cageName, _ } = parseCageNameAndAppFromHost(hostname);
+
+      const cagesAttestationInfo = cagePcrManager.get(cageName);
+
       // we expect undefined when attestation is successful, else an error
       const attestationResult = attestCageConnection(
         hostname,
@@ -209,6 +188,7 @@ function addAttestationListener(
         cagesAttestationInfo,
         attestationCache
       );
+
       if (attestationResult != null) {
         return attestationResult;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evervault/sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@evervault/sdk",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^6.0.2",

--- a/tests/attestationDoc.test.js
+++ b/tests/attestationDoc.test.js
@@ -19,20 +19,6 @@ describe('cageAttestationDoc', () => {
       expect(await cache.get('cage_246')).to.deep.equal('doc');
       cache.disablePolling();
     });
-
-    it('retrieves missing', async () => {
-      let httpStub = {
-        getCageAttestationDoc: sinon.stub().resolves({
-          attestation_doc: 'doc',
-        }),
-      };
-
-      let cages = ['cage_123'];
-      let cache = new AttestationDoc(config(), httpStub, cages, 'app_123');
-      await cache.init();
-      expect(await cache.get('cage')).to.deep.equal('doc');
-      cache.disablePolling();
-    });
   });
 
   context('reload', () => {

--- a/tests/cagePcrManager.test.js
+++ b/tests/cagePcrManager.test.js
@@ -1,0 +1,97 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const config = require('../lib/config');
+const { CagePcrManager } = require('../lib/core');
+
+describe('cagePcrManager', () => {
+  context('constructor', () => {
+    let testPcrs1, testPcrs2;
+
+    beforeEach(() => {
+      testPcrs1 = {
+        pcr0: '0'.repeat(96),
+        pcr1: '1'.repeat(96),
+        pcr2: '2'.repeat(96),
+        pcr8: '8'.repeat(96),
+      };
+
+      testPcrs2 = {
+        pcr0: '4'.repeat(96),
+        pcr1: '5'.repeat(96),
+        pcr2: '6'.repeat(96),
+        pcr8: '7'.repeat(96),
+      };
+    });
+
+    it('retrieves the attestation docs from a provider and starts polling', async () => {
+      let testProvider = () => {
+        return new Promise((resolve) => {
+          resolve([testPcrs1]);
+        });
+      };
+
+      let testAttestationData = { cage_123: testProvider };
+
+      let manager = new CagePcrManager(config(), testAttestationData);
+
+      await manager.init();
+
+      expect(await manager.get('cage_123')).to.deep.equal([testPcrs1]);
+
+      manager.disablePolling();
+    });
+
+    it('retrieves the attestation docs from a hardcoded array and starts polling', async () => {
+      let hardcodedArrayProvider = [testPcrs1, testPcrs2];
+
+      let testAttestationData = { cage_123: hardcodedArrayProvider };
+
+      let manager = new CagePcrManager(config(), testAttestationData);
+
+      await manager.init();
+
+      expect(await manager.get('cage_123')).to.deep.equal([
+        testPcrs1,
+        testPcrs2,
+      ]);
+
+      manager.disablePolling();
+    });
+
+    it('retrieves the attestation docs from a hardcoded object and starts polling', async () => {
+      let testAttestationData = { cage_123: testPcrs2 };
+
+      let manager = new CagePcrManager(config(), testAttestationData);
+
+      await manager.init();
+
+      expect(await manager.get('cage_123')).to.deep.equal([testPcrs2]);
+
+      manager.disablePolling();
+    });
+
+    it('retrieves missing in the background', async () => {
+      let testProvider = () => {
+        return new Promise((resolve) => {
+          resolve([testPcrs1]);
+        });
+      };
+
+      let testAttestationData = { cage_123: testProvider };
+
+      let manager = new CagePcrManager(config(), testAttestationData);
+      await manager.init();
+
+      manager.clearStoredPcrs('cage_123');
+
+      expect(await manager.get('cage')).to.deep.equal(undefined);
+
+      //sleep 1 second
+      await new Promise((r) => setTimeout(r, 1000));
+
+      expect(await manager.get('cage')).to.deep.equal([testPcrs1]);
+
+      manager.disablePolling();
+    });
+  });
+});


### PR DESCRIPTION
# Why
Users should be able to pull PCRs from a source for deployments. Eg: Cage deploying - publish new PCRs to public source which clients can pull from. 

# How
Introduced PCRManager which takes in the existing attestationData param with the addition of taking in a callback. If an array or object are passed in for arrays, these are converted to callbacks which return the hardcoded values. The callbacks are then stored in the PCRManager alongside the last retrieved PCRs. Then on startup, the client runs all provider callbacks and store the results. It then polls the provider every 5 minutes.

I've also reduced the polling frequency of the attestation doc cache to five minutes as it can't fetch on a cache miss as the `tls.checkServerIdentity` is synchronous. This led to my concerns below

# Concern
If we don't have PCRs in the manager or an attestation doc in the AD cache (due to failed requests etc..) we cannot fetch them during the `tls.checkServerIdentity` override as it is snychronous. I wonder should we move to an approach similar to the go and ios sdks where we provide a cage session object to make requests from rather than overriding the tls lib?
