### PR TITLE
Add enclave functions to node sdk

### DIFF
--- a/.changeset/dirty-mangos-swim.md
+++ b/.changeset/dirty-mangos-swim.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': minor
+---
+
+Add new enableEnclaves function and deprecate enableCages

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,6 +5,7 @@ const DEFAULT_TUNNEL_HOSTNAME = 'https://relay.evervault.com:443';
 const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
 const DEFAULT_CAGES_CA_HOSTNAME = 'https://cages-ca.evervault.com';
 const DEFAULT_CAGES_HOSTNAME = 'cage.evervault.com';
+const DEFAULT_ENCLAVES_HOSTNAME = 'enclave.evervault.com';
 const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_MAX_FILE_SIZE_IN_MB = 25;
 const DEFAULT_ATTEST_POLL_INTERVAL = 300;
@@ -19,6 +20,8 @@ module.exports = () => ({
     cagesCertHostname:
       process.env.EV_CAGE_CERT_HOSTNAME || DEFAULT_CAGES_CA_HOSTNAME,
     cagesHostname: process.env.EV_CAGES_HOSTNAME || DEFAULT_CAGES_HOSTNAME,
+    enclavesHostname:
+      process.env.EV_ENCLAVES_HOSTNAME || DEFAULT_ENCLAVES_HOSTNAME,
     pollInterval: process.env.EV_POLL_INTERVAL || DEFAULT_POLL_INTERVAL,
     attestationDocPollInterval:
       process.env.EV_ATTEST_POLL_INTERVAL || DEFAULT_ATTEST_POLL_INTERVAL,

--- a/lib/core/attestationDoc.js
+++ b/lib/core/attestationDoc.js
@@ -1,13 +1,14 @@
 const RepeatedTimer = require('./repeatedTimer');
 
 class AttestationDoc {
-  constructor(config, http, cages, appUuid) {
+  constructor(config, http, cages, appUuid, hostname) {
     this.appUuid = appUuid.replace(/_/g, '-');
     this.http = http;
     this.cages = cages;
     this.config = config;
     this.polling = null;
     this.attestationDocCache = {};
+    this.hostname = hostname;
   }
 
   disablePolling = () => {
@@ -24,11 +25,12 @@ class AttestationDoc {
     return null;
   };
 
-  loadCageDoc = async (cageName) => {
+  loadAttestationDoc = async (cageName) => {
     try {
-      const response = await this.http.getCageAttestationDoc(
+      const response = await this.http.getAttestationDoc(
         cageName,
-        this.appUuid
+        this.appUuid,
+        this.hostname
       );
       this.attestationDocCache[cageName] = response.attestation_doc;
     } catch (e) {
@@ -61,7 +63,7 @@ class AttestationDoc {
   _getAttestationDocs = async () => {
     await Promise.all(
       this.cages.map(async (cageName) => {
-        await this.loadCageDoc(cageName, this.appUuid);
+        await this.loadAttestationDoc(cageName, this.appUuid);
       })
     );
   };

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -100,8 +100,10 @@ module.exports = (appUuid, apiKey, config) => {
     return response.body;
   };
 
-  const getCageAttestationDoc = async (cageName, appUuid) => {
-    let url = `https://${cageName}.${appUuid}.${config.cagesHostname}/.well-known/attestation`;
+  const getAttestationDoc = async (cageName, appUuid, hostname) => {
+    let url = `https://${cageName}.${appUuid}.${
+      hostname ? hostname : config.cagesHostname
+    }/.well-known/attestation`;
     const response = await phin({
       url,
       method: 'GET',
@@ -286,6 +288,6 @@ module.exports = (appUuid, apiKey, config) => {
     getRelayOutboundConfig,
     decrypt,
     createToken,
-    getCageAttestationDoc,
+    getAttestationDoc,
   };
 };

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -3,6 +3,6 @@ module.exports = {
   Http: require('./http'),
   Labs: require('./labs'),
   RelayOutboundConfig: require('./relayOutboundConfig'),
-  AttestationDoc: require('./cageAttestationDoc'),
-  CagePcrManager: require('./cagePcrManager'),
+  AttestationDoc: require('./attestationDoc'),
+  PcrManager: require('./pcrManager'),
 };

--- a/lib/core/pcrManager.js
+++ b/lib/core/pcrManager.js
@@ -10,9 +10,9 @@ staticPcrsToProvider = (pcrs) => {
   return { pcrs, provider };
 };
 
-loadPcrStore = (cageAttestationData) => {
+loadPcrStore = (attestationData) => {
   const providers = {};
-  for (const [cageName, value] of Object.entries(cageAttestationData)) {
+  for (const [cageName, value] of Object.entries(attestationData)) {
     if (Array.isArray(value)) {
       providers[cageName] = staticPcrsToProvider(value);
     } else if (typeof value === 'object') {

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -32,7 +32,7 @@ declare module '@evervault/sdk' {
     ) => Promise<void>;
     createRelayHttpsAgent: () => HttpsProxyAgent;
     /**
-     * @deprecated use enableCages instead
+     * @deprecated use enableEnclaves instead
      */
     enableCages: (
       cageAttestationData: Record<

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -31,6 +31,9 @@ declare module '@evervault/sdk' {
       >
     ) => Promise<void>;
     createRelayHttpsAgent: () => HttpsProxyAgent;
+    /**
+     * @deprecated use enableCages instead
+     */
     enableCages: (
       cageAttestationData: Record<
         string,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,14 +2,13 @@ const crypto = require('crypto');
 const https = require('https');
 const retry = require('async-retry');
 const { Buffer } = require('buffer');
-const util = require('util');
 
 const {
   Datatypes,
   errors,
   validationHelper,
   httpsHelper,
-  cageAttest,
+  attest,
 } = require('./utils');
 const Config = require('./config');
 const {
@@ -17,13 +16,21 @@ const {
   Http,
   RelayOutboundConfig,
   AttestationDoc,
-  CagePcrManager,
+  PcrManager,
 } = require('./core');
 const { TokenCreationError } = require('./utils/errors');
 const console = require('console');
 const HttpsProxyAgent = require('./utils/proxyAgent');
 
 const originalRequest = https.request;
+
+/**
+ * @typedef PCRs
+ * @property {string | undefined} PCR0
+ * @property {string | undefined} PCR1
+ * @property {string | undefined} PCR2
+ * @property {string | undefined} PCR8
+ */
 
 class EvervaultClient {
   static CURVES = {
@@ -80,12 +87,9 @@ class EvervaultClient {
    * @deprecated use enableCages instead
    */
   async enableCagesBeta(cagesAttestationData) {
-    if (cageAttest.hasAttestationBindings()) {
-      await cageAttest.trustCagesRootCA(this.http);
-      cageAttest.addAttestationListenerBeta(
-        this.config.http,
-        cagesAttestationData
-      );
+    if (attest.hasAttestationBindings()) {
+      await attest.trustCagesRootCA(this.http);
+      attest.addAttestationListenerBeta(this.config.http, cagesAttestationData);
     } else {
       console.error(
         'EVERVAULT ERROR :: Cannot enable Cages Beta without installing the Evervault attestation bindings'
@@ -93,8 +97,11 @@ class EvervaultClient {
     }
   }
 
+  /**
+   * @deprecated use enableEnclaves instead
+   */
   async enableCages(cagesAttestationData) {
-    if (cageAttest.hasAttestationBindings()) {
+    if (attest.hasAttestationBindings()) {
       //Store attestation documents from cages in cache
       let attestationCache = new AttestationDoc(
         this.config,
@@ -106,21 +113,53 @@ class EvervaultClient {
       await attestationCache.init();
 
       //Store client PCR providers to periodically pull new PCRs
-      const cagePcrManager = new CagePcrManager(
-        this.config,
-        cagesAttestationData
-      );
+      const pcrManager = new PcrManager(this.config, cagesAttestationData);
 
-      await cagePcrManager.init();
+      await pcrManager.init();
 
-      cageAttest.addAttestationListener(
+      attest.addAttestationListener(
         this.config.http,
         attestationCache,
-        cagePcrManager
+        pcrManager
       );
     } else {
       console.error(
         'EVERVAULT ERROR :: Cannot enable Cages without installing the Evervault attestation bindings'
+      );
+    }
+  }
+
+  /**
+   * @param {{ [key: string]: PCRs | PCRs[] | (() => Promise<PCRs | PCRs[]>) }} attestationData
+   * @throws {import('./utils/errors').MalformedAttestationData}
+   */
+  async enableEnclaves(attestationData) {
+    attest.validateAttestationData(attestationData);
+    if (attest.hasAttestationBindings()) {
+      //Store attestation documents in cache
+      let attestationCache = new AttestationDoc(
+        this.config.http,
+        this.http,
+        Object.keys(attestationData),
+        this.appId,
+        this.config.http.enclavesHostname
+      );
+
+      await attestationCache.init();
+
+      //Store client PCR providers to periodically pull new PCRs
+      const pcrManager = new PcrManager(Config, attestationData);
+
+      await pcrManager.init();
+
+      attest.addAttestationListener(
+        this.config.http,
+        attestationCache,
+        pcrManager
+      );
+    } else {
+      console.error(
+        'EVERVAULT ERROR :: Cannot enable Enclaves without installing the Evervault attestation bindings'
       );
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ class EvervaultClient {
   }
 
   /**
-   * @deprecated use enableCages instead
+   * @deprecated use enableEnclaves instead
    */
   async enableCagesBeta(cagesAttestationData) {
     if (attest.hasAttestationBindings()) {

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -1,5 +1,5 @@
 const certHelper = require('./certHelper');
-const { CageAttestationError } = require('./errors');
+const { CageAttestationError, MalformedAttestationData } = require('./errors');
 const tls = require('tls');
 const origCreateSecureContext = tls.createSecureContext;
 const origCheckServerIdentity = tls.checkServerIdentity;
@@ -139,22 +139,6 @@ function attestCageConnection(
   }
 }
 
-async function getCageAttestationDoc(
-  cageName,
-  cert,
-  pcrsList,
-  attestationCache
-) {
-  const attestationDoc = await attestationCache.get(cageName);
-  if (!attestationDoc) {
-    let attestationDocBytes = Buffer.from(attestationDoc, 'base64');
-    attestationBindings.attestCage(cert, pcrsList, attestationDocBytes);
-  } else {
-    console.warn(`No attestation doc found for ${cageName}`);
-    false;
-  }
-}
-
 function addAttestationListenerBeta(config, cagesAttestationInfo) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
@@ -174,7 +158,7 @@ function addAttestationListenerBeta(config, cagesAttestationInfo) {
   };
 }
 
-function addAttestationListener(config, attestationCache, cagePcrManager) {
+function addAttestationListener(config, attestationCache, pcrManager) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
     if (hostname.endsWith(config.cagesHostname)) {
@@ -182,7 +166,7 @@ function addAttestationListener(config, attestationCache, cagePcrManager) {
       const attestationResult = attestCageConnection(
         hostname,
         cert.raw,
-        cagePcrManager,
+        pcrManager,
         attestationCache
       );
 
@@ -195,6 +179,32 @@ function addAttestationListener(config, attestationCache, cagePcrManager) {
   };
 }
 
+/**
+ * Ensure that the provided attestation data is correctly structured
+ * @param {unknown} providedAttestationData
+ * @throws {MalformedAttestationData}
+ */
+function validateAttestationData(providedAttestationData) {
+  const isObject = (val) =>
+    val != null && typeof val === 'object' && !Array.isArray(val);
+
+  if (!isObject(providedAttestationData)) {
+    throw new MalformedAttestationData(
+      `Expected an object to be provided as attestation data, received ${
+        Array.isArray(providedAttestationData) ? 'Array' : typeof val
+      }`
+    );
+  }
+  const containsOnlyObjects = Object.values(providedAttestationData).every(
+    isObject
+  );
+  if (!containsOnlyObjects) {
+    throw new MalformedAttestationData(
+      'Expected only objects as values in the attestation data map'
+    );
+  }
+}
+
 module.exports = {
   trustCagesRootCA,
   addAttestationListener,
@@ -203,4 +213,5 @@ module.exports = {
   hasAttestationBindings,
   addAttestationListenerBeta,
   attestCageConnectionBeta,
+  validateAttestationData,
 };

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -25,6 +25,12 @@ class CageAttestationError extends EvervaultError {
   }
 }
 
+class MalformedAttestationData extends EvervaultError {
+  constructor(message) {
+    super(`Malformed attestation data provided - ${message}`);
+  }
+}
+
 class ExceededMaxFileSizeError extends EvervaultError {}
 
 class TokenCreationError extends EvervaultError {}
@@ -82,4 +88,5 @@ module.exports = {
   FunctionTimeoutError,
   FunctionNotReadyError,
   FunctionRuntimeError,
+  MalformedAttestationData,
 };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -6,5 +6,5 @@ module.exports = {
   certHelper: require('./certHelper'),
   validationHelper: require('./validationHelper'),
   httpsHelper: require('./httpsHelper'),
-  cageAttest: require('./cageAttest'),
+  attest: require('./attest'),
 };

--- a/tests/attestationDoc.test.js
+++ b/tests/attestationDoc.test.js
@@ -3,11 +3,11 @@ const sinon = require('sinon');
 const config = require('../lib/config');
 const { AttestationDoc } = require('../lib/core');
 
-describe('cageAttestationDoc', () => {
+describe('attestationDoc', () => {
   context('constructor', () => {
     it('retrieves the attestation docs from relevant cages and starts polling', async () => {
       let httpStub = {
-        getCageAttestationDoc: sinon.stub().resolves({
+        getAttestationDoc: sinon.stub().resolves({
           attestation_doc: 'doc',
         }),
       };
@@ -24,10 +24,10 @@ describe('cageAttestationDoc', () => {
   context('reload', () => {
     it('the cache is updated for a single Cage', async () => {
       const httpStub = {
-        getCageAttestationDoc: () => {},
+        getAttestationDoc: () => {},
       };
 
-      let stub = sinon.stub(httpStub, 'getCageAttestationDoc');
+      let stub = sinon.stub(httpStub, 'getAttestationDoc');
       stub.onCall(0).returns({ attestation_doc: 'doc1' });
       stub.onCall(1).returns({ attestation_doc: 'doc2' });
       stub.onCall(2).returns({ attestation_doc: 'doc3' });
@@ -36,7 +36,7 @@ describe('cageAttestationDoc', () => {
       let cache = new AttestationDoc(config(), httpStub, cages, 'app_123');
       await cache.init();
       expect(await cache.get('cage_1')).to.deep.equal('doc1');
-      await cache.loadCageDoc('cage_1', 'app_123');
+      await cache.loadAttestationDoc('cage_1', 'app_123');
       expect(await cache.get('cage_1')).to.deep.equal('doc3');
       cache.disablePolling();
     });
@@ -55,10 +55,10 @@ describe('cageAttestationDoc', () => {
       };
 
       const httpStub = {
-        getCageAttestationDoc: () => {},
+        getAttestationDoc: () => {},
       };
 
-      let stub = sinon.stub(httpStub, 'getCageAttestationDoc');
+      let stub = sinon.stub(httpStub, 'getAttestationDoc');
       stub.onCall(0).returns({ attestation_doc: 'doc1' });
       stub.onCall(1).returns({ attestation_doc: 'doc2' });
 

--- a/tests/pcrManager.test.js
+++ b/tests/pcrManager.test.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const config = require('../lib/config');
-const { CagePcrManager } = require('../lib/core');
+const { PcrManager } = require('../lib/core');
 
-describe('cagePcrManager', () => {
+describe('PcrManager', () => {
   context('constructor', () => {
     let testPcrs1, testPcrs2;
 
@@ -32,7 +32,7 @@ describe('cagePcrManager', () => {
 
       let testAttestationData = { cage_123: testProvider };
 
-      let manager = new CagePcrManager(config(), testAttestationData);
+      let manager = new PcrManager(config(), testAttestationData);
 
       await manager.init();
 
@@ -46,7 +46,7 @@ describe('cagePcrManager', () => {
 
       let testAttestationData = { cage_123: hardcodedArrayProvider };
 
-      let manager = new CagePcrManager(config(), testAttestationData);
+      let manager = new PcrManager(config(), testAttestationData);
 
       await manager.init();
 
@@ -61,7 +61,7 @@ describe('cagePcrManager', () => {
     it('retrieves the attestation docs from a hardcoded object and starts polling', async () => {
       let testAttestationData = { cage_123: testPcrs2 };
 
-      let manager = new CagePcrManager(config(), testAttestationData);
+      let manager = new PcrManager(config(), testAttestationData);
 
       await manager.init();
 
@@ -79,7 +79,7 @@ describe('cagePcrManager', () => {
 
       let testAttestationData = { cage_123: testProvider };
 
-      let manager = new CagePcrManager(config(), testAttestationData);
+      let manager = new PcrManager(config(), testAttestationData);
       await manager.init();
 
       manager.clearStoredPcrs('cage_123');

--- a/tests/utils/attest.test.js
+++ b/tests/utils/attest.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
-const { cageAttest, errors } = require('../../lib/utils');
+const { attest, errors } = require('../../lib/utils');
 const config = require('../../lib/config');
 
 /**
@@ -9,18 +9,18 @@ const config = require('../../lib/config');
  * To avoid false negatives, these tests will only run when the FAKETIME env var is set
  */
 const fakeTimeTests =
-  process.env.FAKETIME != null && cageAttest.hasAttestationBindings()
+  process.env.FAKETIME != null && attest.hasAttestationBindings()
     ? describe
     : describe.skip;
 
-describe('cageAttestBeta', () => {
+describe('attestBeta', () => {
   describe('parseCageNameAndAppFromHost', () => {
     const testCage = 'my-cage';
     const testApp = 'my-app';
     const hostname = 'cages.evervault.com';
     context('Request to base cage host name', () => {
       it('returns expected cage name', () => {
-        const cageName = cageAttest.parseCageNameAndAppFromHost(
+        const cageName = attest.parseCageNameAndAppFromHost(
           `${testCage}.${testApp}.${hostname}`
         );
         expect(cageName).to.deep.equal({
@@ -31,7 +31,7 @@ describe('cageAttestBeta', () => {
     });
     context('Request to cage nonce subdomain', () => {
       it('returns expected cage name', () => {
-        const cageName = cageAttest.parseCageNameAndAppFromHost(
+        const cageName = attest.parseCageNameAndAppFromHost(
           `noncey.attest.${testCage}.${testApp}.${hostname}`
         );
         expect(cageName).to.deep.equal({
@@ -61,7 +61,7 @@ describe('cageAttestBeta', () => {
 
     context('given a valid cert and PCRs', () => {
       it('successfully attests the connection', () => {
-        const result = cageAttest.attestCageConnectionBeta(
+        const result = attest.attestCageConnectionBeta(
           `${cageName}.${appUuid}.${hostname}`,
           {
             raw: derCert,
@@ -76,7 +76,7 @@ describe('cageAttestBeta', () => {
 
     context('given a valid cert and no PCRs', () => {
       it('successfully attests the connection', () => {
-        const result = cageAttest.attestCageConnectionBeta(
+        const result = attest.attestCageConnectionBeta(
           `${cageName}.${appUuid}.${hostname}`,
           {
             raw: derCert,
@@ -88,7 +88,7 @@ describe('cageAttestBeta', () => {
 
     context('given a valid cert and some PCRs', () => {
       it('successfully attests the connection', () => {
-        const result = cageAttest.attestCageConnectionBeta(
+        const result = attest.attestCageConnectionBeta(
           `${cageName}.${appUuid}.${hostname}`,
           {
             raw: derCert,
@@ -108,7 +108,7 @@ describe('cageAttestBeta', () => {
         try {
           const invalidPCRs = { ...validPCRs };
           invalidPCRs.pcr8 = validPCRs.pcr0;
-          cageAttest.attestCageConnectionBeta(
+          attest.attestCageConnectionBeta(
             `${cageName}.${appUuid}.${hostname}`,
             {
               raw: derCert,

--- a/tests/utils/attestGA.test.js
+++ b/tests/utils/attestGA.test.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
-const { cageAttest } = require('../../lib/utils');
-const { AttestationDoc, CagePcrManager } = require('../../lib/core');
+const { attest } = require('../../lib/utils');
+const { AttestationDoc, PcrManager } = require('../../lib/core');
 const config = require('../../lib/config');
 const sinon = require('sinon');
 const { CageAttestationError } = require('../../lib/utils/errors');
@@ -12,11 +12,11 @@ const { CageAttestationError } = require('../../lib/utils/errors');
  * To avoid false negatives, these tests will only run when the FAKETIME env var is set
  */
 const fakeTimeTests =
-  process.env.FAKETIME != null && cageAttest.hasAttestationBindings()
+  process.env.FAKETIME != null && attest.hasAttestationBindings()
     ? describe
     : describe.skip;
 
-describe('cageAttestGA', async () => {
+describe('attestGA', async () => {
   fakeTimeTests('attestCageConnectionGA', async () => {
     const cageName = 'a-test-of-attest';
     const appUuid = 'app_452e33b20b42';
@@ -39,10 +39,37 @@ describe('cageAttestGA', async () => {
     );
 
     let httpStub = {
-      getCageAttestationDoc: sinon
+      getAttestationDoc: sinon
         .stub()
         .resolves(JSON.parse(attestationDocResponse)),
     };
+
+    afterEach(() => {
+      httpStub.getAttestationDoc.resetHistory();
+    });
+
+    context('validateAttestationData', () => {
+      it('Throws a MalformedAttestationData error if the data is not an object', () => {
+        try {
+          attest.validateAttestationData([]);
+        } catch (err) {
+          expect(err).to.be.instanceOf(MalformedAttestationData);
+        }
+      });
+
+      it('Throws a MalformedAttestationData error if the data contains non-object values', () => {
+        try {
+          attest.validateAttestationData({ 'my-cage': true });
+        } catch (err) {
+          expect(err).to.be.instanceOf(MalformedAttestationData);
+        }
+      });
+
+      it('Does not throw when the values in the object are themselves objects', () => {
+        const result = attest.validateAttestationData({ 'my-cage': {} });
+        expect(result).to.be.undefined;
+      });
+    });
 
     context('given a valid cert and PCRs', async () => {
       it('successfully attests the connection', async () => {
@@ -55,7 +82,7 @@ describe('cageAttestGA', async () => {
         };
 
         let testAttestationData = { [cageName]: testProvider };
-        let manager = new CagePcrManager(config(), testAttestationData);
+        let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
         const result = await cageAttest.attestCageConnection(
@@ -70,6 +97,46 @@ describe('cageAttestGA', async () => {
       });
     });
 
+    context(
+      'given a valid cert and PCRs with an alternative hostname',
+      async () => {
+        it('calls the cage at the alternative hostname, and  successfully attests the connection', async () => {
+          let cache = new AttestationDoc(
+            config.http,
+            httpStub,
+            [cageName],
+            appUuid,
+            'enclave.evervault.com'
+          );
+          await cache.init();
+          let testProvider = () => {
+            return new Promise((resolve) => {
+              resolve([validPCRs]);
+            });
+          };
+
+          let testAttestationData = { [cageName]: testProvider };
+          let manager = new PcrManager(config.http, testAttestationData);
+          await manager.init();
+
+          const result = await attest.attestCageConnection(
+            `${cageName}.${appUuid}.${hostname}`,
+            derCert,
+            manager,
+            cache
+          );
+          expect(result).to.be.undefined;
+          expect(httpStub.getAttestationDoc).to.have.been.calledWith(
+            cageName,
+            appUuid.replace('_', '-'),
+            'enclave.evervault.com'
+          );
+          cache.disablePolling();
+          manager.disablePolling();
+        });
+      }
+    );
+
     context('given a valid cert and no PCRs', async () => {
       it('successfully attests the connection', async () => {
         let cache = new AttestationDoc(config(), httpStub, [cageName], appUuid);
@@ -81,7 +148,7 @@ describe('cageAttestGA', async () => {
         };
 
         let testAttestationData = { [cageName]: testProvider };
-        let manager = new CagePcrManager(config(), testAttestationData);
+        let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
         const result = await cageAttest.attestCageConnection(
@@ -102,7 +169,7 @@ describe('cageAttestGA', async () => {
         await cache.init();
 
         let testAttestationData = { [cageName]: validPCRs };
-        let manager = new CagePcrManager(config(), testAttestationData);
+        let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
         const result = await cageAttest.attestCageConnection(
@@ -128,7 +195,7 @@ describe('cageAttestGA', async () => {
           );
           await cache.init();
           let testAttestationData = { [cageName]: invalidPCR };
-          let manager = new CagePcrManager(config(), testAttestationData);
+          let manager = new PcrManager(config(), testAttestationData);
           await manager.init();
 
           await cageAttest.attestCageConnection(

--- a/tests/utils/attestGA.test.js
+++ b/tests/utils/attestGA.test.js
@@ -105,7 +105,7 @@ describe('attestGA', async () => {
       async () => {
         it('calls the cage at the alternative hostname, and  successfully attests the connection', async () => {
           let cache = new AttestationDoc(
-            config,
+            config(),
             httpStub,
             [cageName],
             appUuid,
@@ -119,7 +119,7 @@ describe('attestGA', async () => {
           };
 
           let testAttestationData = { [cageName]: testProvider };
-          let manager = new PcrManager(config.http, testAttestationData);
+          let manager = new PcrManager(config(), testAttestationData);
           await manager.init();
 
           const result = await attest.attestCageConnection(

--- a/tests/utils/attestGA.test.js
+++ b/tests/utils/attestGA.test.js
@@ -5,7 +5,10 @@ const { attest } = require('../../lib/utils');
 const { AttestationDoc, PcrManager } = require('../../lib/core');
 const config = require('../../lib/config');
 const sinon = require('sinon');
-const { CageAttestationError } = require('../../lib/utils/errors');
+const {
+  CageAttestationError,
+  MalformedAttestationData,
+} = require('../../lib/utils/errors');
 
 /**
  * Note: these tests are time sensitive, so are expected to fail when used without libfaketime
@@ -85,7 +88,7 @@ describe('attestGA', async () => {
         let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
-        const result = await cageAttest.attestCageConnection(
+        const result = await attest.attestCageConnection(
           `${cageName}.${appUuid}.${hostname}`,
           derCert,
           manager,
@@ -102,7 +105,7 @@ describe('attestGA', async () => {
       async () => {
         it('calls the cage at the alternative hostname, and  successfully attests the connection', async () => {
           let cache = new AttestationDoc(
-            config.http,
+            config,
             httpStub,
             [cageName],
             appUuid,
@@ -151,7 +154,7 @@ describe('attestGA', async () => {
         let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
-        const result = await cageAttest.attestCageConnection(
+        const result = await attest.attestCageConnection(
           `${cageName}.${appUuid}.${hostname}`,
           derCert,
           manager,
@@ -172,7 +175,7 @@ describe('attestGA', async () => {
         let manager = new PcrManager(config(), testAttestationData);
         await manager.init();
 
-        const result = await cageAttest.attestCageConnection(
+        const result = await attest.attestCageConnection(
           `${cageName}.${appUuid}.${hostname}`,
           derCert,
           manager,
@@ -198,7 +201,7 @@ describe('attestGA', async () => {
           let manager = new PcrManager(config(), testAttestationData);
           await manager.init();
 
-          await cageAttest.attestCageConnection(
+          await attest.attestCageConnection(
             `${cageName}.${appUuid}.${hostname}`,
             derCert,
             manager,


### PR DESCRIPTION
# Why

Update NodeSDK to have new enclave functions, and deprecate old cage functions

# How

- Update client to have enclave attestation entrypoints exposed
- Add deprecation notice to cage functions
- Make file names more generic, update tests
