### PR TITLE
Patch node sdk typings

### DIFF
--- a/.changeset/healthy-countries-refuse.md
+++ b/.changeset/healthy-countries-refuse.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Update typings to include new enableEnclaves function.

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -1,4 +1,8 @@
 declare module '@evervault/sdk' {
+  type PCRs = { pcr0?: string; pcr1?: string; pcr2?: string; pcr8?: string };
+  type AttestationData = Record<string, PCRs | PCRs[]>;
+  type AttestationCallback = () => Promise<PCRs | PCRs[]>;
+
   export default class Evervault {
     constructor(appId: string, apiKey: string);
     encrypt: (data: any) => Promise<any>;
@@ -40,6 +44,9 @@ declare module '@evervault/sdk' {
         | { pcr0?: string; pcr1?: string; pcr2?: string; pcr8?: string }
         | { pcr0?: string; pcr1?: string; pcr2?: string; pcr8?: string }[]
       >
+    ) => Promise<void>;
+    enableEnclaves: (
+      attestationData: Record<string, AttestationData | AttestationCallback>
     ) => Promise<void>;
   }
 }


### PR DESCRIPTION
# Why

Typings in latest release are missing the new `enableEnclaves` function.

# How

Update typings file to include `enableEnclaves`
