### PR TITLE
Patch config object passed to attestation doc cache through enableEnclaves entrypoint

### DIFF
--- a/.changeset/rare-olives-promise.md
+++ b/.changeset/rare-olives-promise.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Fix bug resulting in undefined reference within the AttestationDoc Cache when using the enableEnclaves entrypoint.

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ class EvervaultClient {
     if (attest.hasAttestationBindings()) {
       //Store attestation documents in cache
       let attestationCache = new AttestationDoc(
-        this.config.http,
+        this.config,
         this.http,
         Object.keys(attestationData),
         this.appId,

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -196,11 +196,11 @@ function validateAttestationData(providedAttestationData) {
     );
   }
   const containsOnlyObjects = Object.values(providedAttestationData).every(
-    isObject
+    (pcrs) => isObject(pcrs) || (Array.isArray(pcrs) && pcrs.every(isObject))
   );
   if (!containsOnlyObjects) {
     throw new MalformedAttestationData(
-      'Expected only objects as values in the attestation data map'
+      'Expected only objects or lists of objects as values in the attestation data map'
     );
   }
 }


### PR DESCRIPTION
# Why

Attestation doc cache was receiving a child of the config on the enableEnclaves entrypoint, but expected the entire config to be provided (as was the case for enableCages). This led to an undefined reference when creating the attestation doc cache.

# How

- Pass the correct config
- Correct validation on the attestation measures.
