### PR TITLE
Patch pcr manager

### DIFF
--- a/.changeset/shy-zebras-hunt.md
+++ b/.changeset/shy-zebras-hunt.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Fix bug with incorrect config being passed to PcrManager constructor

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ class EvervaultClient {
       await attestationCache.init();
 
       //Store client PCR providers to periodically pull new PCRs
-      const pcrManager = new PcrManager(Config, attestationData);
+      const pcrManager = new PcrManager(this.config, attestationData);
 
       await pcrManager.init();
 


### PR DESCRIPTION
# Why

Incorrect config provided to PCR Manager in enableEnclaves function

# How

Pass `this.config` as the config is a builder pattern
