### PR TITLE
Add enclaves hostname to attestation listener

### DIFF
--- a/.changeset/great-snakes-doubt.md
+++ b/.changeset/great-snakes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Add enclaves hostname to attestationListener

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ const DEFAULT_API_URL = 'https://api.evervault.com';
 const DEFAULT_TUNNEL_HOSTNAME = 'https://relay.evervault.com:443';
 const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
 const DEFAULT_CAGES_CA_HOSTNAME = 'https://cages-ca.evervault.com';
+const DEFAULT_CAGES_BETA_HOSTNAME = 'cages.evervault.com';
 const DEFAULT_CAGES_HOSTNAME = 'cage.evervault.com';
 const DEFAULT_ENCLAVES_HOSTNAME = 'enclave.evervault.com';
 const DEFAULT_POLL_INTERVAL = 5;
@@ -19,6 +20,8 @@ module.exports = () => ({
     certHostname: process.env.EV_CERT_HOSTNAME || DEFAULT_CA_HOSTNAME,
     cagesCertHostname:
       process.env.EV_CAGE_CERT_HOSTNAME || DEFAULT_CAGES_CA_HOSTNAME,
+    cagesBetaHostname:
+      process.env.EV_CAGES_BETA_HOSTNAME || DEFAULT_CAGES_BETA_HOSTNAME,
     cagesHostname: process.env.EV_CAGES_HOSTNAME || DEFAULT_CAGES_HOSTNAME,
     enclavesHostname:
       process.env.EV_ENCLAVES_HOSTNAME || DEFAULT_ENCLAVES_HOSTNAME,

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -142,7 +142,7 @@ function attestCageConnection(
 function addAttestationListenerBeta(config, cagesAttestationInfo) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
-    if (hostname.endsWith(config.cagesHostname)) {
+    if (hostname.endsWith(config.cagesBetaHostname)) {
       // we expect undefined when attestation is successful, else an error
       const attestationResult = attestCageConnectionBeta(
         hostname,

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -161,7 +161,10 @@ function addAttestationListenerBeta(config, cagesAttestationInfo) {
 function addAttestationListener(config, attestationCache, pcrManager) {
   tls.checkServerIdentity = function (hostname, cert) {
     // only attempt attestation if the host is a cage
-    if (hostname.endsWith(config.cagesHostname)) {
+    if (
+      hostname.endsWith(config.cagesHostname) ||
+      hostname.endsWith(config.enclavesHostname)
+    ) {
       // we expect undefined when attestation is successful, else an error
       const attestationResult = attestCageConnection(
         hostname,


### PR DESCRIPTION
# Why

The attestation listener was missing the enclaves hostname.

# How

Update to add the enclaves hostname.
Also update the Beta attestation listener to use cagesBetaHostname
