### PR TITLE
fix: correct typings for enableEnclaves, and fix validation function to allow callbacks

### DIFF
--- a/.changeset/breezy-garlics-beg.md
+++ b/.changeset/breezy-garlics-beg.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Correct validation of PCR data given to enableEnclaves - allow for functions to be passed as values in the map.

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -1,7 +1,7 @@
 declare module '@evervault/sdk' {
   type PCRs = { pcr0?: string; pcr1?: string; pcr2?: string; pcr8?: string };
-  type AttestationData = Record<string, PCRs | PCRs[]>;
-  type AttestationCallback = () => Promise<PCRs | PCRs[]>;
+  type AttestationData = PCRs | PCRs[];
+  type AttestationCallback = () => Promise<AttestationData>;
 
   export default class Evervault {
     constructor(appId: string, apiKey: string);

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -208,7 +208,7 @@ function validateAttestationData(providedAttestationData) {
   );
   if (!containsOnlyObjects) {
     throw new MalformedAttestationData(
-      'Expected only objects or lists of objects as values in the attestation data map'
+      'Expected only objects, lists of objects, or functions as values in the attestation data map'
     );
   }
 }

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -191,6 +191,8 @@ function validateAttestationData(providedAttestationData) {
   const isObject = (val) =>
     val != null && typeof val === 'object' && !Array.isArray(val);
 
+  const isFunction = (val) => typeof val === 'function';
+
   if (!isObject(providedAttestationData)) {
     throw new MalformedAttestationData(
       `Expected an object to be provided as attestation data, received ${
@@ -199,7 +201,10 @@ function validateAttestationData(providedAttestationData) {
     );
   }
   const containsOnlyObjects = Object.values(providedAttestationData).every(
-    (pcrs) => isObject(pcrs) || (Array.isArray(pcrs) && pcrs.every(isObject))
+    (pcrs) =>
+      isObject(pcrs) ||
+      (Array.isArray(pcrs) && pcrs.every(isObject)) ||
+      isFunction(pcrs)
   );
   if (!containsOnlyObjects) {
     throw new MalformedAttestationData(


### PR DESCRIPTION
# Why
The validation used on the parameters given to enableEnclaves is incorrect - it does not allow for callbacks to be given as values in the map. The typings were also incorrect, showing that a nested record was supported.

# How
Correct typings - only advertise support for an object of PCRs, a list of objects of PCRs or functions as values in the map.
Correct validation - allow functions to be given as values.
