### PR TITLE
Make repeated timers headless

### DIFF
--- a/.changeset/rich-comics-divide.md
+++ b/.changeset/rich-comics-divide.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Make polling jobs scheduled by the SDK headless to allow processes to exit cleanly.

--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const Evervault = require('../lib');
 const axios = require('axios');
+const { v4 } = require('uuid');
 
 describe('Outbound Relay Test', () => {
   const appUuid = process.env.EV_APP_UUID;
@@ -23,7 +24,10 @@ describe('Outbound Relay Test', () => {
       const encrypted = await evervaultClient.encrypt(payload);
 
       await evervaultClient.enableOutboundRelay();
-      const response = await axios.post(syntheticEndpointUrl, encrypted);
+      const response = await axios.post(
+        `${syntheticEndpointUrl}?syntheticUuid=${v4()}&mode=outbound`,
+        encrypted
+      );
       const body = response.data;
       expect(body.request.string).to.equal(false);
       expect(body.request.number).to.equal(false);

--- a/lib/core/attestationDoc.js
+++ b/lib/core/attestationDoc.js
@@ -54,6 +54,8 @@ class AttestationDoc {
     if (!this.polling) {
       this.polling = RepeatedTimer(pollingInterval, this._getAttestationDocs);
     }
+
+    return this.polling;
   };
 
   clearCache = () => {

--- a/lib/core/pcrManager.js
+++ b/lib/core/pcrManager.js
@@ -114,6 +114,8 @@ class CagePcrManager {
     if (!this.polling) {
       this.polling = RepeatedTimer(pollingInterval, this._getPcrs);
     }
+
+    return this.polling;
   };
 
   clearStoredPcrs = () => {

--- a/lib/core/relayOutboundConfig.js
+++ b/lib/core/relayOutboundConfig.js
@@ -49,6 +49,7 @@ const init = async (config, http) => {
   if (!polling) {
     polling = RepeatedTimer(pollingInterval, getRelayOutboundConfigFromApi);
   }
+  return polling;
 };
 
 module.exports = {

--- a/lib/core/repeatedTimer.js
+++ b/lib/core/repeatedTimer.js
@@ -1,12 +1,14 @@
 module.exports = (defaultInterval, cb) => {
   const createInterval = () => {
-    return setInterval(async () => {
+    const initializedInterval = setInterval(async () => {
       try {
         await cb();
       } catch (e) {
         console.error(`EVERVAULT :: An error occurred while polling (${e})`);
       }
     }, interval * 1000);
+    initializedInterval.unref();
+    return initializedInterval;
   };
 
   const start = () => {

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -48,5 +48,6 @@ declare module '@evervault/sdk' {
     enableEnclaves: (
       attestationData: Record<string, AttestationData | AttestationCallback>
     ) => Promise<void>;
+    shutdown: () => void;
   }
 }

--- a/lib/evervault.d.ts
+++ b/lib/evervault.d.ts
@@ -24,6 +24,7 @@ declare module '@evervault/sdk' {
       decryptionDomains: string[];
       debugRequests: boolean;
     }) => Promise<void>;
+    disableOutboundRelay: () => void;
     /**
      * @deprecated use enableCages instead
      */
@@ -48,6 +49,6 @@ declare module '@evervault/sdk' {
     enableEnclaves: (
       attestationData: Record<string, AttestationData | AttestationCallback>
     ) => Promise<void>;
-    shutdown: () => void;
+    disableEnclaves: () => void;
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,10 +100,15 @@ class EvervaultClient {
     }
   }
 
+  /**
+   * The Evervault SDK registers intervals for various features (Relay Outbound, and Enclaves).
+   * These intervals are tracked and can be cancelled using the shutdown function.
+   * Note: the shutdown function may result in your client falling out of sync from these services.
+   */
   shutdown() {
     if (Array.isArray(this._backgroundJobs)) {
       this._backgroundJobs.forEach((interval) => {
-        if (interval.stop) {
+        if (typeof interval.stop === 'function') {
           interval.stop();
         }
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ class EvervaultClient {
     PRIME256V1: 'prime256v1',
   };
 
+  /** @type {Array<ReturnType<import('./core/repeatedTimer')>>} */
+  _backgroundJobs;
   constructor(appId, apiKey, options = {}) {
     if (
       appId === '' ||
@@ -74,6 +76,7 @@ class EvervaultClient {
     this.httpsHelper = httpsHelper;
     this.apiKey = apiKey;
     this.appId = appId;
+    this._backgroundJobs = [];
 
     this.defineHiddenProperty(
       '_ecdh',
@@ -97,6 +100,16 @@ class EvervaultClient {
     }
   }
 
+  shutdown() {
+    if (Array.isArray(this._backgroundJobs)) {
+      this._backgroundJobs.forEach((interval) => {
+        if (interval.stop) {
+          interval.stop();
+        }
+      });
+    }
+  }
+
   /**
    * @deprecated use enableEnclaves instead
    */
@@ -110,12 +123,14 @@ class EvervaultClient {
         this.appId
       );
 
-      await attestationCache.init();
+      const attestationCachePollingRef = await attestationCache.init();
+      this._backgroundJobs.push(attestationCachePollingRef);
 
       //Store client PCR providers to periodically pull new PCRs
       const pcrManager = new PcrManager(this.config, cagesAttestationData);
 
-      await pcrManager.init();
+      const pollingRef = await pcrManager.init();
+      this._backgroundJobs.push(pollingRef);
 
       attest.addAttestationListener(
         this.config.http,
@@ -145,12 +160,14 @@ class EvervaultClient {
         this.config.http.enclavesHostname
       );
 
-      await attestationCache.init();
+      const attestationCachePollingRef = await attestationCache.init();
+      this._backgroundJobs.push(attestationCachePollingRef);
 
       //Store client PCR providers to periodically pull new PCRs
       const pcrManager = new PcrManager(this.config, attestationData);
 
-      await pcrManager.init();
+      const pcrManagerPollingRef = await pcrManager.init();
+      this._backgroundJobs.push(pcrManagerPollingRef);
 
       attest.addAttestationListener(
         this.config.http,
@@ -374,7 +391,11 @@ class EvervaultClient {
       } else {
         debug_request = false;
       }
-      await RelayOutboundConfig.init(this.config, this.http);
+      const relayOutboundPollingRef = await RelayOutboundConfig.init(
+        this.config,
+        this.http
+      );
+      this._backgroundJobs.push(relayOutboundPollingRef);
       await this.httpsHelper.overloadHttpsModule(
         this.apiKey,
         this.config.http.tunnelHostname,

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,8 @@ class EvervaultClient {
     PRIME256V1: 'prime256v1',
   };
 
-  /** @type {Array<ReturnType<import('./core/repeatedTimer')>>} */
+  /** @typedef {ReturnType<import('./core/repeatedTimer')>} Timer */
+  /** @type {{ enclaves: Timer[] | null, relayOutbound: Timer | null}} */
   _backgroundJobs;
   constructor(appId, apiKey, options = {}) {
     if (
@@ -76,7 +77,10 @@ class EvervaultClient {
     this.httpsHelper = httpsHelper;
     this.apiKey = apiKey;
     this.appId = appId;
-    this._backgroundJobs = [];
+    this._backgroundJobs = {
+      relayOutbound: null,
+      enclaves: null,
+    };
 
     this.defineHiddenProperty(
       '_ecdh',
@@ -101,21 +105,6 @@ class EvervaultClient {
   }
 
   /**
-   * The Evervault SDK registers intervals for various features (Relay Outbound, and Enclaves).
-   * These intervals are tracked and can be cancelled using the shutdown function.
-   * Note: the shutdown function may result in your client falling out of sync from these services.
-   */
-  shutdown() {
-    if (Array.isArray(this._backgroundJobs)) {
-      this._backgroundJobs.forEach((interval) => {
-        if (typeof interval.stop === 'function') {
-          interval.stop();
-        }
-      });
-    }
-  }
-
-  /**
    * @deprecated use enableEnclaves instead
    */
   async enableCages(cagesAttestationData) {
@@ -129,13 +118,13 @@ class EvervaultClient {
       );
 
       const attestationCachePollingRef = await attestationCache.init();
-      this._backgroundJobs.push(attestationCachePollingRef);
+      this._backgroundJobs.enclaves = [attestationCachePollingRef];
 
       //Store client PCR providers to periodically pull new PCRs
       const pcrManager = new PcrManager(this.config, cagesAttestationData);
 
       const pollingRef = await pcrManager.init();
-      this._backgroundJobs.push(pollingRef);
+      this._backgroundJobs.enclaves.push(pollingRef);
 
       attest.addAttestationListener(
         this.config.http,
@@ -166,13 +155,13 @@ class EvervaultClient {
       );
 
       const attestationCachePollingRef = await attestationCache.init();
-      this._backgroundJobs.push(attestationCachePollingRef);
+      this._backgroundJobs.enclaves = [attestationCachePollingRef];
 
       //Store client PCR providers to periodically pull new PCRs
       const pcrManager = new PcrManager(this.config, attestationData);
 
       const pcrManagerPollingRef = await pcrManager.init();
-      this._backgroundJobs.push(pcrManagerPollingRef);
+      this._backgroundJobs.enclaves.push(pcrManagerPollingRef);
 
       attest.addAttestationListener(
         this.config.http,
@@ -183,6 +172,14 @@ class EvervaultClient {
       console.error(
         'EVERVAULT ERROR :: Cannot enable Enclaves without installing the Evervault attestation bindings'
       );
+    }
+  }
+
+  disableEnclaves() {
+    if (Array.isArray(this._backgroundJobs.enclaves)) {
+      this._backgroundJobs.enclaves.forEach((enclaveTimer) => {
+        enclaveTimer.stop();
+      });
     }
   }
 
@@ -400,7 +397,7 @@ class EvervaultClient {
         this.config,
         this.http
       );
-      this._backgroundJobs.push(relayOutboundPollingRef);
+      this._backgroundJobs.relayOutbound = relayOutboundPollingRef;
       await this.httpsHelper.overloadHttpsModule(
         this.apiKey,
         this.config.http.tunnelHostname,
@@ -423,6 +420,13 @@ class EvervaultClient {
       );
     }
   }
+
+  disableOutboundRelay() {
+    if (this._backgroundJobs.relayOutbound != null) {
+      this._backgroundJobs.relayOutbound.stop();
+    }
+  }
+
   /**
    * @returns {HttpsProxyAgent}
    */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky install",
     "lint": "prettier --check \"./**/*.js\"",
-    "test": "mocha 'tests/**/*.test.js'",
+    "test": "mocha 'tests/**/*.test.js'  --timeout 30000",
     "test:e2e": "mocha 'e2e/**/*.test.js' --timeout 5000 --exit",
     "test:filter": "mocha 'tests/**/*.test.js' --grep",
     "test:coverage": "nyc --reporter=text npm run test"


### PR DESCRIPTION
# Why
SDK instances which make use of the RepeatedTimer module will prevent NodeJS processes from exiting by remaining scheduled in the event loop.

# How
Update the RepeatedTimer module to make the intervals headless using the `unref` function from the node Timer type. This will allow Node processes to exit cleanly without waiting for the interval to shutdown.
This PR also introduces a `_backgroundJobs` array on the Node SDK which tracks all open intervals, and allows users to explicitly shut them down using the `shutdown` function.