### PR TITLE
Resolve reference error in PCR manager

### DIFF
--- a/.changeset/honest-seahorses-grow.md
+++ b/.changeset/honest-seahorses-grow.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Declare helper functions in pcrManager as consts.

--- a/lib/core/pcrManager.js
+++ b/lib/core/pcrManager.js
@@ -1,6 +1,6 @@
 const RepeatedTimer = require('./repeatedTimer');
 
-staticPcrsToProvider = (pcrs) => {
+const staticPcrsToProvider = (pcrs) => {
   const provider = async () => {
     return new Promise((resolve) => {
       resolve(pcrs);
@@ -10,7 +10,7 @@ staticPcrsToProvider = (pcrs) => {
   return { pcrs, provider };
 };
 
-loadPcrStore = (attestationData) => {
+const loadPcrStore = (attestationData) => {
   const providers = {};
   for (const [cageName, value] of Object.entries(attestationData)) {
     if (Array.isArray(value)) {


### PR DESCRIPTION
# Why
Utility functions within the PCR Manager were incorrectly declared.

# How
Declare the functions as consts.