### PR TITLE
Revert "New Release"

### DIFF
--- a/.changeset/rotten-singers-check.md
+++ b/.changeset/rotten-singers-check.md
@@ -1,0 +1,27 @@
+---
+'@evervault/sdk': major
+---
+
+The Evervault Attestation Bindings have been removed as an external dependency including them instead as a plugin at runtime.
+
+The attestation bindings now require an explicit opt-in. For customers that do not use Evervault Enclaves, there should be no change to how you use the SDK.
+
+If you use Evervault Enclaves, you'll need to install the Attestation Bindings separately:
+
+```sh
+npm i @evervault/attestation-bindings
+```
+
+After installing the attestation bindings, you can use the existing `enableEnclaves` function using the bindings as the second parameter:
+
+```javascript
+const Evervault = require('@evervault/sdk');
+const attestationBindings = require('@evervault/attestation-bindings');
+
+const evervault = new Evervault('app_id', 'api_key');
+await evervault.enableEnclaves({
+  'my-enclave': {
+    // attestation measures...
+  }
+}, attestationBindings);
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,5 @@
 # @evervault/sdk
 
-## 6.0.0
-
-### Major Changes
-
-- 759861a: The Evervault Attestation Bindings have been removed as an external dependency including them instead as a plugin at runtime.
-
-  The attestation bindings now require an explicit opt-in. For customers that do not use Evervault Enclaves, there should be no change to how you use the SDK.
-
-  If you use Evervault Enclaves, you'll need to install the Attestation Bindings separately:
-
-  ```sh
-  npm i @evervault/attestation-bindings
-  ```
-
-  After installing the attestation bindings, you can use the existing `enableEnclaves` function using the bindings as the second parameter:
-
-  ```javascript
-  const Evervault = require('@evervault/sdk');
-  const attestationBindings = require('@evervault/attestation-bindings');
-
-  const evervault = new Evervault('app_id', 'api_key');
-  await evervault.enableEnclaves(
-    {
-      'my-enclave': {
-        // attestation measures...
-      },
-    },
-    attestationBindings
-  );
-  ```
-
 ## 5.1.6
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/sdk",
-  "version": "6.0.0",
+  "version": "5.1.6",
   "description": "Node.js SDK for Evervault",
   "main": "lib/index.js",
   "typings": "types/index.d.ts",


### PR DESCRIPTION
Reverts evervault/evervault-node#179

The tsc command for generating our types needs to be updated to avoid errors in a dependency's typing file.