### PR TITLE
Add flag to tsc call to support synthetic default imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:filter": "mocha 'tests/**/*.test.js' --grep",
     "test:coverage": "nyc --reporter=text npm run test",
     "prepublishOnly": "npm run generate-types",
-    "generate-types": "tsc lib/*.js lib/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types"
+    "generate-types": "tsc lib/*.js lib/**/*.js --declaration --allowJs --emitDeclarationOnly --allowSyntheticDefaultImports --outDir types"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Why

Latest release is failing to publish due to a typing error in our `agent-base` dependency. It currently imports several node libs as a default, `import net from "net";` instead of using the more correct `import * as net from "net";`.

# How

Allow synthetic default imports
