### PR TITLE
[ETR-2357] Add createEnclaveHttpsAgent for attesting connections to enclave

### DIFF
--- a/.changeset/metal-moles-give.md
+++ b/.changeset/metal-moles-give.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': minor
+---
+
+Added `createEnclaveHttpsAgent` to return an `EnclaveAgent` class which extends https.Agent to manage HTTPS connections. This Agent can be passed into HTTP clients like Axios to attest a connection to an Enclave.

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,8 +6,8 @@ const DEFAULT_CA_HOSTNAME = 'https://ca.evervault.com';
 const DEFAULT_ENCLAVES_HOSTNAME = 'enclave.evervault.com';
 const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_MAX_FILE_SIZE_IN_MB = 25;
-const DEFAULT_ATTEST_POLL_INTERVAL = 300;
-const DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 300;
+const DEFAULT_ATTEST_POLL_INTERVAL = 120;
+const DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 60;
 
 /** @type {import('./types').MasterConfig} */
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,13 @@ class EvervaultClient {
     }
   }
 
+  /**
+   * @param {import('./types') AttestationData} attestationData
+   * @param {import('./types').AttestationBindings} attestationBindings
+   * @param {import('https').AgentOptions} option
+   * @returns {Promise<import('./types').EnclaveAgent>}
+   * @throws {import('./utils/errors').MalformedAttestationData}
+   **/
   async createEnclaveHttpsAgent(attestationData, attestationBindings, options) {
     attest.validateAttestationData(attestationData);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,6 @@ class EvervaultClient {
    * @param {import('./types') AttestationData} attestationData
    * @param {import('./types').AttestationBindings} attestationBindings
    * @param {import('https').AgentOptions} option
-   * @returns {Promise<import('./types').EnclaveAgent>}
    * @throws {import('./utils/errors').MalformedAttestationData}
    **/
   async createEnclaveHttpsAgent(attestationData, attestationBindings, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,32 @@ class EvervaultClient {
     }
   }
 
+  async createEnclaveHttpsAgent(attestationData, attestationBindings, options) {
+    attest.validateAttestationData(attestationData);
+
+    const attestationCache = new AttestationDoc(
+      this.config,
+      this.http,
+      Object.keys(attestationData),
+      this.appId,
+      this.config.http.enclavesHostname
+    );
+    const attestationCachePollingRef = await attestationCache.init();
+    this._backgroundJobs.enclaves = [attestationCachePollingRef];
+
+    const pcrManager = new PcrManager(this.config, attestationData);
+    const pcrManagerPollingRef = await pcrManager.init();
+    this._backgroundJobs.enclaves.push(pcrManagerPollingRef);
+
+    return new attest.EnclaveAgent(
+      options,
+      this.config.http,
+      attestationCache,
+      pcrManager,
+      attestationBindings
+    );
+  }
+
   /** @returns {Promise<string>} */
   async generateNonce() {
     const nonce = await this.crypto.generateBytes(16);

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -78,7 +78,10 @@ function attestConnection(
   }
 }
 
-// Custom HTTPS agent
+/*
+ * Custom agent to handle attestation of connections to enclaves.
+ * Pass this to a https request to ensure that the connection is attested.
+ */
 class EnclaveAgent extends https.Agent {
   /**
    * @param {import('https').AgentOptions} option

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -1,5 +1,7 @@
 const { AttestationError, MalformedAttestationData } = require('./errors');
 const tls = require('tls');
+const https = require('https');
+const { hostname } = require('os');
 const origCheckServerIdentity = tls.checkServerIdentity;
 
 function parseNameAndAppFromHost(hostname) {
@@ -73,6 +75,51 @@ function attestConnection(
       err.message
     );
     return err;
+  }
+}
+
+// Custom HTTPS agent
+class EnclaveAgent extends https.Agent {
+  /**
+   * @param {import('https').AgentOptions} option
+   * @param {import('../core/attestationDoc')} attestationCache
+   * @param {import('../core/pcrManager')} pcrManager
+   * @param {import('../types').AttestationBindings} attestationBindings
+   * */
+  constructor(
+    option,
+    config,
+    attestationCache,
+    pcrManager,
+    attestationBindings
+  ) {
+    super(option);
+    this.config = config;
+    this.attestationCache = attestationCache;
+    this.pcrManager = pcrManager;
+    this.attestationBindings = attestationBindings;
+  }
+
+  #checkEnclaveServerIdentity(hostname, cert) {
+    if (hostname.endsWith(this.agent.config.enclavesHostname)) {
+      const attestationResult = attestConnection(
+        hostname,
+        cert.raw,
+        this.agent.pcrManager,
+        this.agent.attestationCache,
+        this.agent.attestationBindings
+      );
+
+      if (attestationResult != null) {
+        return attestationResult;
+      }
+    }
+    return origCheckServerIdentity(hostname, cert);
+  }
+
+  createConnection(options, callback) {
+    options.checkServerIdentity = this.#checkEnclaveServerIdentity;
+    return tls.connect(options, callback);
   }
 }
 
@@ -151,4 +198,5 @@ module.exports = {
   addAttestationListener,
   parseNameAndAppFromHost,
   validateAttestationData,
+  EnclaveAgent,
 };

--- a/lib/utils/attest.js
+++ b/lib/utils/attest.js
@@ -103,14 +103,14 @@ class EnclaveAgent extends https.Agent {
     this.attestationBindings = attestationBindings;
   }
 
-  #checkEnclaveServerIdentity(hostname, cert) {
-    if (hostname.endsWith(this.agent.config.enclavesHostname)) {
+  #checkEnclaveServerIdentity = (hostname, cert) => {
+    if (hostname.endsWith(this.config.enclavesHostname)) {
       const attestationResult = attestConnection(
         hostname,
         cert.raw,
-        this.agent.pcrManager,
-        this.agent.attestationCache,
-        this.agent.attestationBindings
+        this.pcrManager,
+        this.attestationCache,
+        this.attestationBindings
       );
 
       if (attestationResult != null) {
@@ -118,7 +118,7 @@ class EnclaveAgent extends https.Agent {
       }
     }
     return origCheckServerIdentity(hostname, cert);
-  }
+  };
 
   createConnection(options, callback) {
     options.checkServerIdentity = this.#checkEnclaveServerIdentity;


### PR DESCRIPTION
# Why
Provide a method to create an `EnclaveAgent` which can be passed to a HTTP lib (like axios) for attesting requests. This allows for more control over which requests are attested than the enableEnclaves function which attempts to attest any `.enclaves.evervault.com`.

# How
The SDK now provides an async method `createEnclaveHttpsAgent` which kicks off background polling for Enclave attestation documents and PCR from supplied PCR providers. It then returns an extension of the `https.Agent` class called EnclaveAgent. This can be passed to http libs. It overrides the `checkServerIdentity` method to provide Enclave attestation during a TLS handshake.

# Usage:
```javascript
    const evervault = new Evervault('app_uuid', 'ev:key...');

    const enclaveHttpsAgent = await evervault.createEnclaveHttpsAgent({
        'enclave-name': resolveEnclavePCRsFromEvervaultAPI
    },
        Bindings
    );


    try {
        const result = await axios.post('https://enclave-name.app-uuid.enclave.evervault.com/hello', {
            firstName: 'Fred',
            lastName: 'Flintstone'
        },
        {
            httpsAgent: enclaveHttpsAgent
        });
        console.log(result);
    } catch (error) {
        console.error('Request failed:', error);
    };
```
