### PR TITLE
fix: app uuid header is incorrect

### DIFF
--- a/.changeset/friendly-ladybugs-know.md
+++ b/.changeset/friendly-ladybugs-know.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+fix app key header name

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -69,7 +69,7 @@ module.exports = (appUuid, apiKey, config) => {
   const getAppKey = async () => {
     const getAppKeyCallback = async () => {
       return await get('keys', {
-        'x-evervault-app-uuid': appUuid,
+        'x-evervault-app-id': appUuid,
       }).catch((_e) => {
         throw new errors.EvervaultError(
           "An error occurred while retrieving the app's key"


### PR DESCRIPTION
# Why
Incorrect header name is causing validation errors

# How
- get keys with `x-evervault-app-id` header
