### PR TITLE
Replace phin with axios as phin is unmaintained

### DIFF
--- a/.changeset/green-teachers-flow.md
+++ b/.changeset/green-teachers-flow.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Remvoe phin as a dependency as it is unmaintained

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -175,7 +175,7 @@ module.exports = (appUuid, apiKey, config) => {
       try {
         return await requestCallback().then((response) => {
           if (response.status >= 500) {
-            throw new NotFoundError();
+            throw new errors.EvervaultError('Unknown error occured');
           } else {
             return response;
           }

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -1,6 +1,6 @@
 const { errors, Datatypes } = require('../utils');
 
-const phin = require('phin');
+const axios = require('axios');
 
 /**
  * @param {string} appUuid
@@ -29,7 +29,7 @@ module.exports = (appUuid, apiKey, config) => {
       headers['api-key'] = apiKey;
     }
 
-    return phin({
+    return axios({
       url:
         path.startsWith('https://') || path.startsWith('http://')
           ? path
@@ -37,7 +37,7 @@ module.exports = (appUuid, apiKey, config) => {
       method,
       headers,
       data,
-      parse,
+      validateStatus: (status) => true,
     });
   };
 
@@ -60,8 +60,8 @@ module.exports = (appUuid, apiKey, config) => {
       });
     };
     const response = await makeGetRequestWithRetry(getCagesKeyCallback);
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      return response.body;
+    if (response.status >= 200 && response.status < 300) {
+      return response.data;
     }
     throw errors.mapResponseCodeToError(response);
   };
@@ -77,56 +77,36 @@ module.exports = (appUuid, apiKey, config) => {
       });
     };
     const response = await makeGetRequestWithRetry(getAppKeyCallback);
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      return response.body;
+    if (response.status >= 200 && response.status < 300) {
+      return response.data;
     }
   };
 
   const getCert = async () => {
-    const response = await phin({
-      url: config.certHostname,
-      method: 'GET',
-      parse: 'cer',
-    })
-      .catch(() => {
-        // Blindly retry
-        return phin({
-          url: config.certHostname,
-          method: 'GET',
-          parse: 'cer',
-        });
-      })
+    const response = await axios(config.certHostname)
+      // Blindly retry
+      .catch(() => axios(config.certHostname))
       .catch((err) => {
         throw new errors.EvervaultError(
           `Unable to download cert from ${config.certHostname} (${err.message})`
         );
       });
-    return response.body;
+    return response.data;
   };
 
   const getAttestationDoc = async (enclaveName, appUuid, hostname) => {
     let url = `https://${enclaveName}.${appUuid}.${
       hostname ? hostname : config.enclavesHostname
     }/.well-known/attestation`;
-    const response = await phin({
-      url,
-      method: 'GET',
-      parse: 'json',
-    })
-      .catch(() => {
-        // Blindly retry
-        return phin({
-          url,
-          method: 'GET',
-          parse: 'json',
-        });
-      })
+    const response = await axios(url)
+      // Blindly retry
+      .catch(() => axios(url))
       .catch((err) => {
         throw new errors.EvervaultError(
           `Unable to download attestation doc from ${url} (${err.message})`
         );
       });
-    return response.body;
+    return response.data;
   };
 
   const getRelayOutboundConfig = async () => {
@@ -135,13 +115,13 @@ module.exports = (appUuid, apiKey, config) => {
         `An error occoured while retrieving the Relay Outbound configuration: ${e}`
       );
     });
-    if (response.statusCode >= 200 && response.statusCode < 300) {
+    if (response.status >= 200 && response.status < 300) {
       const pollIntervalHeaderValue = response.headers['x-poll-interval'];
       return {
         pollInterval: isNaN(pollIntervalHeaderValue)
           ? null
           : parseFloat(pollIntervalHeaderValue),
-        data: response.body,
+        data: response.data,
       };
     }
     throw errors.mapResponseCodeToError(response);
@@ -159,15 +139,15 @@ module.exports = (appUuid, apiKey, config) => {
       true
     );
 
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      const responseBody = response.body;
+    if (response.status >= 200 && response.status < 300) {
+      const responseBody = response.data;
       if (responseBody.status === 'success') {
         return response;
       }
       throw errors.mapFunctionFailureResponseToError(responseBody);
     }
 
-    const responseBody = response.body;
+    const responseBody = response.data;
     throw errors.mapApiResponseToError(responseBody);
   };
 
@@ -193,7 +173,13 @@ module.exports = (appUuid, apiKey, config) => {
     let error = null;
     while (retryCount < maxRetries) {
       try {
-        return await requestCallback();
+        return await requestCallback().then((response) => {
+          if (response.status >= 500) {
+            throw new NotFoundError();
+          } else {
+            return response;
+          }
+        });
       } catch (e) {
         retryCount++;
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
@@ -226,16 +212,16 @@ module.exports = (appUuid, apiKey, config) => {
       true,
       'none'
     );
-    if (response.statusCode >= 200 && response.statusCode < 300) {
+    if (response.status >= 200 && response.status < 300) {
       if (contentType === 'application/json') {
-        const { data } = JSON.parse(response.body);
+        const { data } = response.data;
         return data;
       }
-      return response.body;
+      return response.data;
     }
-    const resBody = Buffer.isBuffer(response.body)
-      ? JSON.parse(response.body.toString())
-      : response.body;
+    const resBody = Buffer.isBuffer(response.data)
+      ? JSON.parse(response.data.toString())
+      : response.data;
     throw errors.mapApiResponseToError(resBody);
   };
 
@@ -273,14 +259,14 @@ module.exports = (appUuid, apiKey, config) => {
       true,
       'json'
     );
-    if (response.statusCode >= 200 && response.statusCode < 300) {
+    if (response.status >= 200 && response.status < 300) {
       return {
-        ...response.body,
-        createdAt: new Date(response.body.createdAt),
-        expiry: new Date(response.body.expiry),
+        ...response.data,
+        createdAt: new Date(response.data.createdAt),
+        expiry: new Date(response.data.expiry),
       };
     }
-    throw errors.mapApiResponseToError(response.body);
+    throw errors.mapApiResponseToError(response.data);
   };
 
   return {

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -83,14 +83,13 @@ module.exports = (appUuid, apiKey, config) => {
   };
 
   const getCert = async () => {
-    const response = await axios(config.certHostname)
-      // Blindly retry
-      .catch(() => axios(config.certHostname))
-      .catch((err) => {
-        throw new errors.EvervaultError(
-          `Unable to download cert from ${config.certHostname} (${err.message})`
-        );
-      });
+    const response = await makeGetRequestWithRetry(async () =>
+      axios(config.certHostname)
+    ).catch((err) => {
+      throw new errors.EvervaultError(
+        `Unable to download cert from ${config.certHostname} (${err.message})`
+      );
+    });
     return response.data;
   };
 
@@ -98,14 +97,13 @@ module.exports = (appUuid, apiKey, config) => {
     let url = `https://${enclaveName}.${appUuid}.${
       hostname ? hostname : config.enclavesHostname
     }/.well-known/attestation`;
-    const response = await axios(url)
-      // Blindly retry
-      .catch(() => axios(url))
-      .catch((err) => {
-        throw new errors.EvervaultError(
-          `Unable to download attestation doc from ${url} (${err.message})`
-        );
-      });
+    const response = await makeGetRequestWithRetry(async () =>
+      axios(url)
+    ).catch((err) => {
+      throw new errors.EvervaultError(
+        `Unable to download attestation doc from ${url} (${err.message})`
+      );
+    });
     return response.data;
   };
 
@@ -174,7 +172,7 @@ module.exports = (appUuid, apiKey, config) => {
     while (retryCount < maxRetries) {
       try {
         return await requestCallback().then((response) => {
-          if (response.status >= 500) {
+          if (response.status < 200 || response.status >= 300) {
             throw new errors.EvervaultError('Unknown error occured');
           } else {
             return response;

--- a/lib/index.js
+++ b/lib/index.js
@@ -383,10 +383,10 @@ class EvervaultClient {
         },
         { retries: 3 }
       );
-      return response.body;
+      return response.data;
     } else {
       const response = await this.http.runFunction(functionName, payload);
-      return response.body;
+      return response.data;
     }
   }
 
@@ -401,7 +401,7 @@ class EvervaultClient {
     validationHelper.validateFunctionName(functionName);
 
     const response = await this.http.createRunToken(functionName, payload);
-    return response.body;
+    return response.data;
   }
 
   /**

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -60,29 +60,29 @@ const mapApiResponseToError = ({ code, detail }) => {
   throw new EvervaultError(detail);
 };
 
-const mapResponseCodeToError = ({ statusCode, body, headers }) => {
-  if (statusCode === 401)
+const mapResponseCodeToError = ({ status, data, headers }) => {
+  if (status === 401)
     return new EvervaultError('Invalid authorization provided.');
   if (
-    statusCode === 403 &&
+    status === 403 &&
     headers['x-evervault-error-code'] === 'forbidden-ip-error'
   ) {
     return new EvervaultError(
-      body.message || "IP is not present on the invoked Enclave's whitelist."
+      data.message || "IP is not present on the invoked Enclave's whitelist."
     );
   }
-  if (statusCode === 403) {
+  if (status === 403) {
     return new EvervaultError(
       'The API key provided does not have the required permissions.'
     );
   }
-  if (statusCode === 422) {
-    return new EvervaultError(body.message || 'Unable to decrypt data.');
+  if (status === 422) {
+    return new EvervaultError(data.message || 'Unable to decrypt data.');
   }
-  if (body.message) {
-    return new EvervaultError(body.message);
+  if (data.message) {
+    return new EvervaultError(data.message);
   }
-  return new EvervaultError(`Request returned with status [${statusCode}]`);
+  return new EvervaultError(`Request returned with status [${status}]`);
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "asn1js": "^3.0.5",
     "async-retry": "^1.3.3",
     "crc-32": "^1.2.2",
-    "phin": "^3.5.0",
     "uuid": "^8.1.0"
   },
   "devDependencies": {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -3,7 +3,7 @@ chai.use(require('sinon-chai'));
 const { expect } = chai;
 const nock = require('nock');
 const sinon = require('sinon');
-const phin = require('phin');
+const axios = require('axios');
 const https = require('https');
 const rewire = require('rewire');
 const { RelayOutboundConfig } = require('../lib/core');
@@ -236,7 +236,7 @@ describe('Testing the Evervault SDK', () => {
       const originalRequest = https.request;
 
       const wasProxied = (request, apiKey) => {
-        return request.req.headers['proxy-authorization'] === apiKey;
+        return request.request.headers['proxy-authorization'] === apiKey;
       };
 
       afterEach(() => {
@@ -264,7 +264,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -287,7 +287,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -310,7 +310,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.io');
+        const response = await axios('https://destination1.evervault.io');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -323,7 +323,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -336,7 +336,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -350,7 +350,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -365,7 +365,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 
@@ -379,7 +379,7 @@ describe('Testing the Evervault SDK', () => {
           .get('/')
           .reply(200, { success: true });
 
-        const response = await phin('https://destination1.evervault.test');
+        const response = await axios('https://destination1.evervault.test');
         expect(wasProxied(response, testApiKey)).to.be.true;
       });
 

--- a/tests/core/http.test.js
+++ b/tests/core/http.test.js
@@ -144,7 +144,7 @@ describe('Http Module', () => {
           .runFunction(testFunction, { test: 'data' })
           .then((res) => {
             expect(runFunctionNock.isDone()).to.be.true;
-            expect(res.body).to.deep.equal(testResponse);
+            expect(res.data).to.deep.equal(testResponse);
           });
       });
     });
@@ -513,7 +513,7 @@ describe('Http Module', () => {
             .createRunToken(testFunction, { test: 'data' })
             .then((res) => {
               expect(createRunTokenNock.isDone()).to.be.true;
-              expect(res.body).to.deep.equal(testResponse);
+              expect(res.data).to.deep.equal(testResponse);
             });
         });
       });
@@ -531,8 +531,8 @@ describe('Http Module', () => {
             .createRunToken(testFunction, { test: 'data' })
             .then((res) => {
               expect(createRunTokenNock.isDone()).to.be.true;
-              expect(res.statusCode).to.equal(404);
-              expect(res.body).to.deep.equal(testResponse);
+              expect(res.status).to.equal(404);
+              expect(res.data).to.deep.equal(testResponse);
             });
         });
       });

--- a/tests/httpHelper.test.js
+++ b/tests/httpHelper.test.js
@@ -39,9 +39,9 @@ describe('overload https requests', () => {
         evClient,
         originalRequest
       );
-      const phin = require('phin');
+      const axios = require('axios');
 
-      return await phin(testUrl).then((result) => {
+      return await axios(testUrl).then((result) => {
         expect(wasProxied(result)).to.be.false;
       });
     });


### PR DESCRIPTION
# Why

`phin` is unmaintained. We considered using `got`, but it only supports the ESM module system and migrating the repo to that would be scope creep. We also considered using `fetch` but native `fetch` doesn't work with some parts of the code for outbound relay and we would end up relying on axios anyway.

# How

Replace phin code with axios equivalents.