### PR TITLE
Add axios

### DIFF
--- a/.changeset/two-dodos-swim.md
+++ b/.changeset/two-dodos-swim.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Add axios dependency

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "asn1js": "^3.0.5",
     "async-retry": "^1.3.3",
     "crc-32": "^1.2.2",
-    "uuid": "^8.1.0"
-    "axios": "^1.5.0",
+    "uuid": "^8.1.0",
+    "axios": "^1.5.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async-retry": "^1.3.3",
     "crc-32": "^1.2.2",
     "uuid": "^8.1.0",
-    "axios": "^1.5.0"
+    "axios": "^1.7.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "async-retry": "^1.3.3",
     "crc-32": "^1.2.2",
     "uuid": "^8.1.0"
+    "axios": "^1.5.0",
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
-    "axios": "^1.5.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "husky": "^7.0.2",


### PR DESCRIPTION
# Why

Axios was only referenced as a dev dependency and wasn't being installed by default with the evervault-node package

# How

Move axios to dependencies section.
