### PR TITLE
feat: add support for including target path in request filtering

### DIFF
--- a/.changeset/tiny-years-bake.md
+++ b/.changeset/tiny-years-bake.md
@@ -1,0 +1,27 @@
+---
+'@evervault/sdk': minor
+---
+
+Extend Relay outbound/forward proxy support in Node to include the ability to filter requests by path using `decryptionDomains`.
+
+Requests can be filtered at the path level by appending an absolute or wildcard path to the decryption domains option, following similar wildcard logic to the domains
+themselves. For example:
+
+```js
+// Existing behaviour will be observed, proxying requests to the host 'api.com'.
+const ev = new Evervault('app_uuid', 'api_key', {
+  decryptionDomains: ['api.com']
+});
+
+// Will only proxy requests to host 'api.com' which have a path starting with '/users/'.
+const ev = new Evervault('app_uuid', 'api_key', {
+  decryptionDomains: ['api.com/users/*']
+});
+
+// Will only proxy requests to host 'api.com' which have an exact path of '/settings'.
+const ev = new Evervault('app_uuid', 'api_key', {
+  decryptionDomains: ['api.com/settings']
+});
+```
+
+This change is compatible with the existing hostname wildcard behaviour of `decryptionDomains`.

--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -1,5 +1,8 @@
 const { expect } = require('chai');
 const Evervault = require('../lib');
+const {
+  http: { proxiedMarker },
+} = require('../lib/config');
 const axios = require('axios');
 const { v4 } = require('uuid');
 
@@ -32,6 +35,7 @@ describe('Outbound Relay Test', () => {
       expect(body.request.string).to.equal(false);
       expect(body.request.number).to.equal(false);
       expect(body.request.boolean).to.equal(false);
+      expect(response.request[proxiedMarker]).to.equal(true);
     });
   });
 });

--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -38,4 +38,79 @@ describe('Outbound Relay Test', () => {
       expect(response.request[proxiedMarker]).to.equal(true);
     });
   });
+
+  context('Enable Outbound Relay with decryption domains', () => {
+    it('Proxies the listed domains correctly, ignoring others', async () => {
+      const payload = {
+        string: 'some_string',
+        number: 1234567890,
+        boolean: true,
+      };
+      const encrypted = await evervaultClient.encrypt(payload);
+
+      await evervaultClient.enableOutboundRelay({
+        decryptionDomains: ['httpbin.org'],
+      });
+
+      const [httpbinRes, syntheticRes] = await Promise.allSettled([
+        axios.post('https://httpbin.org/post', encrypted),
+        axios.get(syntheticEndpointUrl),
+      ]);
+
+      expect(httpbinRes.value.request[proxiedMarker]).to.equal(true);
+      expect(syntheticRes.value.request[proxiedMarker]).to.equal(false);
+    });
+  });
+
+  context(
+    'Enable Outbound Relay with decryption domains including paths',
+    () => {
+      it('Filters requests by path', async () => {
+        const payload = {
+          string: 'some_string',
+          number: 1234567890,
+          boolean: true,
+        };
+        const encrypted = await evervaultClient.encrypt(payload);
+
+        await evervaultClient.enableOutboundRelay({
+          decryptionDomains: ['httpbin.org/post'],
+        });
+
+        const [postRes, getRes] = await Promise.allSettled([
+          axios.post('https://httpbin.org/post', encrypted),
+          axios.get('https://httpbin.org/get'),
+        ]);
+
+        expect(postRes.value.request[proxiedMarker]).to.equal(true);
+        expect(getRes.value.request[proxiedMarker]).to.equal(false);
+      });
+    }
+  );
+
+  context(
+    'Enable Outbound Relay with decryption domains including paths with wildcards',
+    () => {
+      it('Filters requests by path, respecting wildcards', async () => {
+        const payload = {
+          string: 'some_string',
+          number: 1234567890,
+          boolean: true,
+        };
+        const encrypted = await evervaultClient.encrypt(payload);
+
+        await evervaultClient.enableOutboundRelay({
+          decryptionDomains: ['httpbin.org/post/*'],
+        });
+
+        const [matchingPostRes, failingPostRes] = await Promise.allSettled([
+          axios.post('https://httpbin.org/post/somewhere', encrypted),
+          axios.get('https://httpbin.org/post'),
+        ]);
+
+        expect(matchingPostRes.value.request[proxiedMarker]).to.equal(true);
+        expect(failingPostRes.value.request[proxiedMarker]).to.equal(false);
+      });
+    }
+  );
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,7 @@ module.exports = {
     pcrProviderPollInterval:
       process.env.EV_PCR_PROVIDER_POLL_INTERVAL ||
       DEFAULT_PCR_PROVIDER_POLL_INTERVAL,
+    proxiedMarker: Symbol.for('request-proxied'),
   },
   encryption: {
     secp256k1: {

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -6,7 +6,6 @@ const axios = require('axios');
  * @param {string} appUuid
  * @param {string} apiKey
  * @param {import('../types').HttpConfig} config
- * @returns
  */
 module.exports = (appUuid, apiKey, config) => {
   const request = (

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ const {
 } = require('./core');
 const { TokenCreationError } = require('./utils/errors');
 const HttpsProxyAgent = require('./utils/proxyAgent');
+const { importTarget, matchTarget } = require('./utils/domainTargets');
 
 const originalRequest = https.request;
 
@@ -222,13 +223,17 @@ class EvervaultClient {
   /**
    * @private
    * @param {string[]} decryptionDomains
-   * @returns {(domain: string) => boolean}
+   * @returns {(domain: string, path: string) => boolean}
    */
   _decryptionDomainsFilter(decryptionDomains) {
-    return (domain) =>
+    const parsedDomains = decryptionDomains
+      .map((decryptionDomain) => importTarget(decryptionDomain))
+      .filter((importedTarget) => importedTarget != null);
+    return (domain, path) =>
       this._isDecryptionDomain(
         domain,
-        decryptionDomains,
+        path,
+        parsedDomains,
         this._alwaysIgnoreDomains()
       );
   }
@@ -236,44 +241,22 @@ class EvervaultClient {
   /**
    * @private
    * @param {string} domain
-   * @param {string[]} decryptionDomains
+   * @param {string} path
+   * @param {import('./utils/domainTargets').Target[]} decryptionDomains
    * @param {string[]} alwaysIgnore
    */
-  _isDecryptionDomain(domain, decryptionDomains, alwaysIgnore) {
+  _isDecryptionDomain(domain, path, decryptionDomains, alwaysIgnore) {
     if (alwaysIgnore.includes(domain)) return false;
-    return decryptionDomains.some((decryptionDomain) => {
-      if (decryptionDomain.charAt(0) === '*') {
-        return domain.endsWith(decryptionDomain.substring(1));
-      } else {
-        return decryptionDomain === domain;
-      }
-    });
+    return decryptionDomains.some((decryptionDomain) =>
+      matchTarget(domain, path, decryptionDomain)
+    );
   }
 
-  /** @private @returns {(domain: string) => boolean} */
+  /** @private @returns {(domain: string, path: string) => boolean} */
   _relayOutboundConfigDomainFilter() {
-    return (domain) => {
-      return this._isDecryptionDomain(
-        domain,
-        RelayOutboundConfig.getDecryptionDomains(),
-        this._alwaysIgnoreDomains()
-      );
-    };
-  }
-
-  /**
-   * @private
-   * @param {string} domain
-   * @param {string[]} exactDomains
-   * @param {string[]} endsWithDomains
-   * @returns {boolean}
-   */
-  _exactOrEndsWith(domain, exactDomains, endsWithDomains) {
-    if (exactDomains.includes(domain)) return true;
-    for (let end of endsWithDomains) {
-      if (domain && domain.endsWith(end)) return true;
-    }
-    return false;
+    return this._decryptionDomainsFilter(
+      RelayOutboundConfig.getDecryptionDomains()
+    ).bind(this);
   }
 
   /**

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -7,6 +7,7 @@ export interface HttpConfig {
   pollInterval: string | number;
   attestationDocPollInterval: string | number;
   pcrProviderPollInterval: string | number;
+  proxiedMarker: Symbol;
 }
 
 export interface CurveConfig {

--- a/lib/utils/domainTargets.d.ts
+++ b/lib/utils/domainTargets.d.ts
@@ -1,0 +1,14 @@
+export type MatcherSpecificity = "wildcard" | "absolute";
+export type MatcherType = "host" | "path";
+
+export interface Target {
+  rawValue: string;
+  host: Matcher;
+  path?: Matcher;
+}
+
+export interface Matcher {
+  specificity: MatcherSpecificity;
+  type: MatcherType;
+  value: string;
+}

--- a/lib/utils/domainTargets.js
+++ b/lib/utils/domainTargets.js
@@ -1,0 +1,114 @@
+/**
+ * Grouping of helpers and types to aid reasoning about destinations when intercepting outbound traffic.
+ */
+
+/**
+ * Apply the matching logic based on the matcher type and specificity.
+ * @param {string} givenValue
+ * @param {import("./domainTargets").Matcher} matcher
+ */
+function applyMatch(givenValue, matcher) {
+  if (matcher.specificity === 'absolute') {
+    return givenValue === matcher.value;
+  }
+  if (matcher.type === 'host') {
+    return givenValue.endsWith(matcher.value);
+  }
+  if (matcher.type === 'path') {
+    return givenValue.startsWith(matcher.value);
+  }
+  return false;
+}
+
+/**
+ * Apply a target matcher against the given host and path combination. If a path matcher is defined on the target, it will only match if *both* the host and path match.
+ * @param {string} requestedHost
+ * @param {string} requestedPath
+ * @param {import('./domainTargets').Target} target
+ */
+function matchTarget(requestedHost, requestedPath, target) {
+  if (target.path != null) {
+    return (
+      applyMatch(requestedHost, target.host) &&
+      applyMatch(requestedPath, target.path)
+    );
+  }
+  return applyMatch(requestedHost, target.host);
+}
+
+/**
+ * Check if the given hostname includes a protocol prefix.
+ * @param {string} val
+ * @returns {boolean}
+ */
+function startsWithProto(val) {
+  return val.startsWith('https://') || val.startsWith('http://');
+}
+
+/**
+ * Create a matcher object from a hostname string. If the hostname begins with an asterisk, it will be treated as a wildcard matcher.
+ * @param {string} host
+ * @return {import('./domainTargets').Matcher}
+ */
+function buildHostMatcher(host) {
+  const specificity = host.startsWith('*') ? 'wildcard' : 'absolute';
+  const value = specificity === 'wildcard' ? host.slice(1) : host;
+  return {
+    type: 'host',
+    specificity,
+    value,
+  };
+}
+
+/**
+ * Create a matcher object from a path string. If the string ends with an asterisk, it will be treated as a wildcard matcher.
+ * @param {string} path
+ * @return {import('./domainTargets').Matcher}
+ */
+function buildPathMatcher(path) {
+  const specificity = path.endsWith('*') ? 'wildcard' : 'absolute';
+  const value = specificity === 'wildcard' ? path.slice(0, -1) : path;
+  return {
+    type: 'path',
+    specificity,
+    value,
+  };
+}
+
+/**
+ * Convert a user provided input into a target matcher, lightly validating the input in the process.
+ * @param {unknown} rawInputValue
+ * @returns {import("./domainTargets").Target | null}
+ */
+function importTarget(rawInputValue) {
+  if (typeof rawInputValue !== 'string' || rawInputValue.length === 0) {
+    return null;
+  }
+
+  // Targets are expected to be domains with optional paths.
+  if (startsWithProto(rawInputValue)) {
+    return null;
+  }
+
+  const startPathIndex = rawInputValue.indexOf('/');
+  if (startPathIndex === -1) {
+    return {
+      rawValue: rawInputValue,
+      host: buildHostMatcher(rawInputValue),
+    };
+  }
+
+  const hostname = rawInputValue.slice(0, startPathIndex);
+  const path = rawInputValue.slice(startPathIndex);
+
+  return {
+    rawValue: rawInputValue,
+    host: buildHostMatcher(hostname),
+    path: buildPathMatcher(path),
+  };
+}
+
+module.exports = {
+  importTarget,
+  matchTarget,
+};

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -75,7 +75,7 @@ const overloadHttpsModule = (
     for (const arg of args) {
       if (arg instanceof Object) {
         domain = domain ?? arg.hostname ?? arg.host;
-        path = domain ?? arg.pathname;
+        path = path ?? arg.pathname;
       }
     }
     return {

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -3,6 +3,9 @@ const tls = require('tls');
 const Datatypes = require('./datatypes');
 const certHelper = require('./certHelper');
 const HttpsProxyAgent = require('./proxyAgent');
+const {
+  http: { proxiedMarker },
+} = require('../config');
 const origCreateSecureContext = tls.createSecureContext;
 const EVERVAULT_DOMAINS = ['evervault.com', 'evervault.io', 'evervault.dev'];
 
@@ -111,7 +114,9 @@ const overloadHttpsModule = (
       }
       return arg;
     });
-    return originalRequest.apply(this, args);
+    const request = originalRequest.apply(this, args);
+    request[proxiedMarker] = shouldProxy;
+    return request;
   }
 
   https.request = wrapMethodRequest;

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -38,6 +38,11 @@ const certificateUtil = (evClient) => {
 
 /**
  * @param {string} apiKey
+ * @param {string} tunnelHostname
+ * @param {(domain: string, path: string) => boolean} domainFilter
+ * @param {boolean} debugRequests
+ * @param {ReturnType<typeof import('../core/http')>} evClient
+ * @param {typeof import('node:https').request} originalRequest
  * @returns {void}
  */
 const overloadHttpsModule = (
@@ -48,27 +53,41 @@ const overloadHttpsModule = (
   evClient,
   originalRequest
 ) => {
-  function getDomainFromArgs(args) {
+  /**
+   *
+   * @param {Parameters<typeof import('node:https').request>} args
+   * @returns {{ host: string, path?: string }}
+   */
+  function getDomainAndPathFromArgs(args) {
     if (typeof args[0] === 'string') {
-      return new URL(args[0]).host;
+      const parsedUrl = new URL(args[0]);
+      return { host: parsedUrl.host, path: parsedUrl.pathname };
     }
 
-    if (args.url) {
-      return args.url.match(domainRegex)[0];
+    if (args[0] instanceof URL) {
+      return { host: args[0].host, path: args[0].pathname };
     }
 
-    let domain;
+    let domain, path;
     for (const arg of args) {
       if (arg instanceof Object) {
-        domain = domain || arg.hostname || arg.host;
+        domain = domain ?? arg.hostname ?? arg.host;
+        path = domain ?? arg.pathname;
       }
     }
-    return domain;
+    return {
+      domain,
+      path,
+    };
   }
 
+  /**
+   * @param {Parameters<typeof import('node:https').request>} args
+   * @returns {ReturnType<typeof import('node:https').request>}
+   */
   function wrapMethodRequest(...args) {
-    const domain = getDomainFromArgs(args);
-    const shouldProxy = domainFilter(domain);
+    const { domain, path } = getDomainAndPathFromArgs(args);
+    const shouldProxy = domainFilter(domain, path);
     if (
       debugRequests &&
       !EVERVAULT_DOMAINS.some((evervault_domain) =>
@@ -76,7 +95,7 @@ const overloadHttpsModule = (
       )
     ) {
       console.log(
-        `EVERVAULT DEBUG :: Request to domain: ${domain}, Outbound Proxy enabled: ${shouldProxy}`
+        `EVERVAULT DEBUG :: Request to domain: ${domain}${path}, Outbound Proxy enabled: ${shouldProxy}`
       );
     }
     args = args.map((arg) => {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   Datatypes: require('./datatypes'),
+  domainTargets: require('./domainTargets'),
   errors: require('./errors'),
   certHelper: require('./certHelper'),
   environment: require('./environment'),

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha 'tests/**/*.test.js'  --timeout 30000",
     "test:e2e": "mocha 'e2e/**/*.test.js' --timeout 5000 --exit",
     "test:filter": "mocha 'tests/**/*.test.js' --grep",
+    "test:e2e:filter": "mocha 'e2e/**/*.test.js' --timeout 5000 --grep",
     "test:coverage": "nyc --reporter=text npm run test",
     "prepublishOnly": "npm run generate-types",
     "generate-types": "tsc lib/*.js lib/**/*.js --declaration --allowJs --emitDeclarationOnly --allowSyntheticDefaultImports --outDir types"

--- a/tests/utils/domainTargets.test.js
+++ b/tests/utils/domainTargets.test.js
@@ -1,0 +1,202 @@
+const { expect } = require('chai');
+
+const { domainTargets } = require('../../lib/utils');
+
+describe('domainTargets', () => {
+  context('importTarget', () => {
+    context('Absolute domain correctly formatted, no path', () => {
+      it('imports the domain correctly', () => {
+        const result = domainTargets.importTarget('google.com');
+        expect(result).to.not.be.null;
+        expect(result.rawValue).to.equal('google.com');
+        expect(result.host.value).to.equal('google.com');
+        expect(result.host.specificity).to.equal('absolute');
+        expect(result.path).to.be.undefined;
+      });
+    });
+
+    context('Absolute domain and path', () => {
+      it('imports the domain and path correctly', () => {
+        const result = domainTargets.importTarget('google.com/users');
+        expect(result).to.not.be.null;
+        expect(result.rawValue).to.equal('google.com/users');
+        expect(result.host.value).to.equal('google.com');
+        expect(result.host.specificity).to.equal('absolute');
+        expect(result.path).to.not.be.undefined;
+        expect(result.path.value).to.equal('/users');
+        expect(result.path.specificity).to.equal('absolute');
+      });
+    });
+
+    context('Wildcard domain, absolute path', () => {
+      it('imports the domain and path correctly', () => {
+        const result = domainTargets.importTarget('*.google.com/users');
+        expect(result).to.not.be.null;
+        expect(result.rawValue).to.equal('*.google.com/users');
+        expect(result.host.value).to.equal('.google.com');
+        expect(result.host.specificity).to.equal('wildcard');
+        expect(result.path).to.not.be.undefined;
+        expect(result.path.value).to.equal('/users');
+        expect(result.path.specificity).to.equal('absolute');
+      });
+    });
+
+    context('Wildcard domain, wildcard path', () => {
+      it('imports the domain and path correctly', () => {
+        const result = domainTargets.importTarget('*.google.com/users/*');
+        expect(result).to.not.be.null;
+        expect(result.rawValue).to.equal('*.google.com/users/*');
+        expect(result.host.value).to.equal('.google.com');
+        expect(result.host.specificity).to.equal('wildcard');
+        expect(result.path).to.not.be.undefined;
+        expect(result.path.value).to.equal('/users/');
+        expect(result.path.specificity).to.equal('wildcard');
+      });
+    });
+
+    context('Absolute domain, wildcard path', () => {
+      it('imports the domain and path correctly', () => {
+        const result = domainTargets.importTarget('google.com/users/*');
+        expect(result).to.not.be.null;
+        expect(result.rawValue).to.equal('google.com/users/*');
+        expect(result.host.value).to.equal('google.com');
+        expect(result.host.specificity).to.equal('absolute');
+        expect(result.path).to.not.be.undefined;
+        expect(result.path.value).to.equal('/users/');
+        expect(result.path.specificity).to.equal('wildcard');
+      });
+    });
+
+    context('Invalid domain with leading protocol', () => {
+      it('Ignores the domain', () => {
+        const result = domainTargets.importTarget('https://google.com/users/*');
+        expect(result).to.be.null;
+      });
+    });
+
+    context('Invalid domain type', () => {
+      it('Ignores the domain', () => {
+        const result = domainTargets.importTarget(false);
+        expect(result).to.be.null;
+      });
+    });
+  });
+
+  context('matchTarget', () => {
+    context('absolute domain matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('google.com');
+        const result = domainTargets.matchTarget(
+          'google.com',
+          '/users',
+          target
+        );
+        expect(result).to.be.true;
+      });
+    });
+
+    context('absolute domain not matching input', () => {
+      it('returns false', () => {
+        const target = domainTargets.importTarget('google.com');
+        const result = domainTargets.matchTarget('api.com', '/users', target);
+        expect(result).to.be.false;
+      });
+    });
+
+    context('wildcard domain matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('*.google.com');
+        const result = domainTargets.matchTarget(
+          'api.google.com',
+          '/users',
+          target
+        );
+        expect(result).to.be.true;
+      });
+    });
+
+    context('wildcard domain not matching input', () => {
+      it('returns false', () => {
+        const target = domainTargets.importTarget('*.google.com');
+        const result = domainTargets.matchTarget(
+          'api.somewhere.com',
+          '/users',
+          target
+        );
+        expect(result).to.be.false;
+      });
+    });
+
+    context('absolute domain and path matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('google.com/users/foo');
+        const result = domainTargets.matchTarget(
+          'google.com',
+          '/users/foo',
+          target
+        );
+        expect(result).to.be.true;
+      });
+    });
+
+    context('absolute domain and path not matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('google.com/users/foo');
+        const result = domainTargets.matchTarget(
+          'google.com',
+          '/users',
+          target
+        );
+        expect(result).to.be.false;
+      });
+    });
+
+    context('absolute domain and wildcard path matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('google.com/users/*');
+        const result = domainTargets.matchTarget(
+          'google.com',
+          '/users/foo',
+          target
+        );
+        expect(result).to.be.true;
+      });
+    });
+
+    context('absolute domain and wildcard path not matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('google.com/users/*');
+        const result = domainTargets.matchTarget(
+          'google.com',
+          '/settings',
+          target
+        );
+        expect(result).to.be.false;
+      });
+    });
+
+    context('wildcard domain and wildcard path matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('*.google.com/users/*');
+        const result = domainTargets.matchTarget(
+          'api.google.com',
+          '/users/foo',
+          target
+        );
+        expect(result).to.be.true;
+      });
+    });
+
+    context('wildcard domain and wildcard path not matching input', () => {
+      it('returns true', () => {
+        const target = domainTargets.importTarget('*.google.com/users/*');
+        const result = domainTargets.matchTarget(
+          'api.somewhere.com',
+          '/settings',
+          target
+        );
+        expect(result).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Why

We want to extend support for request filtering when sending via forward proxy to account for the path if specific on the decryptionDomains.

# How

- Add domainTarget which builds a small 'target' object from the provided list of domains. The target object wraps the ability to match a request based on hostname and optionally target
- Update all request intercept logic to include the domain and path
- Update the jsdoc typing comments to be more accurate.
- Tidy up some unused code