### PR TITLE
Fix extracting domain from url

### DIFF
--- a/.changeset/few-beers-draw.md
+++ b/.changeset/few-beers-draw.md
@@ -1,0 +1,7 @@
+---
+"@evervault/sdk": patch
+---
+
+Correct logic for parsing domains from URLs supplied to the http request function: add fallback support for path alongisde pathname.
+
+Fix bug in parsing raw strings supplied to request to URLs by correcting object keys.

--- a/lib/utils/httpsHelper.js
+++ b/lib/utils/httpsHelper.js
@@ -40,6 +40,34 @@ const certificateUtil = (evClient) => {
 };
 
 /**
+ *
+ * @param {Parameters<typeof import('node:https').request>} args
+ * @returns {{ domain: string, path: string }}
+ */
+function getDomainAndPathFromArgs(args) {
+  if (typeof args[0] === 'string') {
+    const parsedUrl = new URL(args[0]);
+    return { domain: parsedUrl.host, path: parsedUrl.pathname };
+  }
+
+  if (args[0] instanceof URL) {
+    return { domain: args[0].host, path: args[0].pathname };
+  }
+
+  let domain, path;
+  for (const arg of args) {
+    if (arg instanceof Object) {
+      domain = domain ?? arg.hostname ?? arg.host;
+      path = path ?? arg.pathname ?? arg.path;
+    }
+  }
+  return {
+    domain,
+    path,
+  };
+}
+
+/**
  * @param {string} apiKey
  * @param {string} tunnelHostname
  * @param {(domain: string, path: string) => boolean} domainFilter
@@ -57,40 +85,12 @@ const overloadHttpsModule = (
   originalRequest
 ) => {
   /**
-   *
-   * @param {Parameters<typeof import('node:https').request>} args
-   * @returns {{ host: string, path?: string }}
-   */
-  function getDomainAndPathFromArgs(args) {
-    if (typeof args[0] === 'string') {
-      const parsedUrl = new URL(args[0]);
-      return { host: parsedUrl.host, path: parsedUrl.pathname };
-    }
-
-    if (args[0] instanceof URL) {
-      return { host: args[0].host, path: args[0].pathname };
-    }
-
-    let domain, path;
-    for (const arg of args) {
-      if (arg instanceof Object) {
-        domain = domain ?? arg.hostname ?? arg.host;
-        path = path ?? arg.pathname;
-      }
-    }
-    return {
-      domain,
-      path,
-    };
-  }
-
-  /**
    * @param {Parameters<typeof import('node:https').request>} args
    * @returns {ReturnType<typeof import('node:https').request>}
    */
   function wrapMethodRequest(...args) {
     const { domain, path } = getDomainAndPathFromArgs(args);
-    const shouldProxy = domainFilter(domain, path);
+    const shouldProxy = !!domain && domainFilter(domain, path);
     if (
       debugRequests &&
       !EVERVAULT_DOMAINS.some((evervault_domain) =>
@@ -147,4 +147,5 @@ const httpsRelayAgent = (
 module.exports = {
   overloadHttpsModule,
   httpsRelayAgent,
+  getDomainAndPathFromArgs,
 };

--- a/tests/httpHelper.test.js
+++ b/tests/httpHelper.test.js
@@ -4,6 +4,24 @@ const { expect } = require('chai');
 const https = require('https');
 const fs = require('fs');
 
+describe('getDomainAndPathFromArgs', () => {
+  [
+    [new URL('https://a.com'), 'a.com', '/'],
+    [new URL('https://a.com/b/c'), 'a.com', '/b/c'],
+    ['https://a.com', 'a.com', '/'],
+    ['https://a.com/b/c', 'a.com', '/b/c'],
+    [{ hostname: 'a.com', pathname: '/' }, 'a.com', '/'],
+    [{ host: 'a.com', path: '/' }, 'a.com', '/'],
+    [{ yayForJavascript: 1 }, undefined, undefined],
+  ].forEach(([url, expectedDomain, expectedPath], i) => {
+    it(`works for ${JSON.stringify(url)} (${i})`, () => {
+      const result = httpsHelper.getDomainAndPathFromArgs([url]);
+      expect(result.domain).to.equal(expectedDomain);
+      expect(result.path).to.equal(expectedPath);
+    });
+  });
+});
+
 describe('overload https requests', () => {
   const apiKey = 'test-api-key';
   const tunnelHostname = 'relay.evervault.com';


### PR DESCRIPTION
Bug introduced in https://github.com/evervault/evervault-node/pull/206

It wasn't handling `.path` which is happening for us, and it seems node request supports

And also noticed for the `Url` case it was returning `host` instead of `domain` so would be ignored 🙈
