### PR TITLE
Pass response type to axios for file decrypt requests

### DIFF
--- a/.changeset/modern-jeans-wave.md
+++ b/.changeset/modern-jeans-wave.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Correct axios response type for file decrypt requests.

--- a/e2e/encryptDecrypt.test.js
+++ b/e2e/encryptDecrypt.test.js
@@ -172,9 +172,9 @@ describe('Encrypt and Decrypt', () => {
       expect(payload).to.deep.equal(decrypted);
     });
 
-    it('encrypts file with metadata and decryption is permitted', async () => {
+    it('encrypts file, and decrypts successfully', async () => {
       const payload = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
-      const encrypted = await evervaultClient.encrypt(payload, 'permit-all');
+      const encrypted = await evervaultClient.encrypt(payload);
       const decrypted = await evervaultClient.decrypt(encrypted);
       expect(payload).to.deep.equal(decrypted);
     });

--- a/e2e/encryptDecrypt.test.js
+++ b/e2e/encryptDecrypt.test.js
@@ -172,6 +172,13 @@ describe('Encrypt and Decrypt', () => {
       expect(payload).to.deep.equal(decrypted);
     });
 
+    it('encrypts file with metadata and decryption is permitted', async () => {
+      const payload = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+      const encrypted = await evervaultClient.encrypt(payload, 'permit-all');
+      const decrypted = await evervaultClient.decrypt(encrypted);
+      expect(payload).to.deep.equal(decrypted);
+    });
+
     it('encrypts with metadata and decryption is not permitted', async () => {
       const payload = {
         string: 'hello',

--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -14,7 +14,7 @@ module.exports = (appUuid, apiKey, config) => {
     additionalHeaders = {},
     data = undefined,
     basicAuth = false,
-    parse = 'json'
+    responseType = 'json'
   ) => {
     const headers = {
       'user-agent': config.userAgent,
@@ -36,7 +36,8 @@ module.exports = (appUuid, apiKey, config) => {
       method,
       headers,
       data,
-      validateStatus: (status) => true,
+      validateStatus: (_) => true,
+      responseType,
     });
   };
 
@@ -47,8 +48,8 @@ module.exports = (appUuid, apiKey, config) => {
     data,
     headers = { 'Content-Type': 'application/json' },
     basicAuth = false,
-    parse = 'json'
-  ) => request('POST', path, headers, data, basicAuth, parse);
+    responseType = 'json'
+  ) => request('POST', path, headers, data, basicAuth, responseType);
 
   const getCageKey = async () => {
     const getCagesKeyCallback = async () => {
@@ -191,14 +192,17 @@ module.exports = (appUuid, apiKey, config) => {
   const decrypt = async (encryptedData) => {
     let contentType;
     let data;
+    let responseType;
     if (Buffer.isBuffer(encryptedData)) {
       contentType = 'application/octet-stream';
       data = encryptedData;
+      responseType = 'arraybuffer';
     } else {
       contentType = 'application/json';
       data = {
         data: encryptedData,
       };
+      responseType = 'json';
     }
     const response = await post(
       `${config.baseUrl}/decrypt`,
@@ -207,7 +211,7 @@ module.exports = (appUuid, apiKey, config) => {
         'Content-Type': contentType,
       },
       true,
-      'none'
+      responseType
     );
     if (response.status >= 200 && response.status < 300) {
       if (contentType === 'application/json') {


### PR DESCRIPTION
# Why

Without passing a response type, axios assumes that responses contain json. This is causing decrypted files to be corrupted when returned from the SDK.

# How

Pass response type to the decrypt post request as `arraybuffer` for files, so we can return the raw octet stream