### PR TITLE
Fix/createtoken timestamp bug

### DIFF
--- a/lib/core/http.js
+++ b/lib/core/http.js
@@ -230,7 +230,7 @@ module.exports = (appUuid, apiKey, config) => {
     let wellFormedExpiry;
     if (expiry) {
       if (expiry && expiry instanceof Date) {
-        wellFormedExpiry = expiry.getUTCMilliseconds();
+        wellFormedExpiry = expiry.getTime();
       } else if (expiry && typeof expiry === 'number') {
         wellFormedExpiry = expiry;
       } else {
@@ -239,7 +239,7 @@ module.exports = (appUuid, apiKey, config) => {
         );
       }
 
-      const now = new Date().getUTCMilliseconds();
+      const now = Date.now();
       if (wellFormedExpiry < now || wellFormedExpiry - now > 600000) {
         throw new errors.TokenCreationError(
           'Expiry must be in the next 10 minutes'


### PR DESCRIPTION
## Summary
Fixed bug in the `createToken` function where `getUTCMilliseconds()` was incorrectly used instead of `getTime()`.

## The Bug
`getUTCMilliseconds()` returns only the milliseconds component (0-999) of a date, not the full Unix timestamp. This caused the expiry validation to fail incorrectly when comparing timestamps.

## Changes
- Replace `expiry.getUTCMilliseconds()` with `expiry.getTime()` to get the full timestamp (line 233)
- Replace `new Date().getUTCMilliseconds()` with `Date.now()` for getting current timestamp (line 242)

## Impact
This bug would have caused the expiry validation to always fail since it was comparing millisecond values (0-999) instead of actual Unix timestamps. With this fix, the token expiry validation will work correctly.