### PR TITLE
Change NPM token secret for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,5 @@ jobs:
             echo "No tag attached to HEAD. No new release needed."
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_NPM_PUBLISH }}
 


### PR DESCRIPTION
# Why

Incorrect secret being used for npm publish caused workflow to fail

# How

Standardize to common secret.
