### PR TITLE
Revert "New Release" to re-run with correct npm token

### DIFF
--- a/.changeset/chilly-cycles-tap.md
+++ b/.changeset/chilly-cycles-tap.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': patch
+---
+
+Bumping axios to fix vulnerability

--- a/.changeset/strong-singers-visit.md
+++ b/.changeset/strong-singers-visit.md
@@ -1,0 +1,5 @@
+---
+'@evervault/sdk': minor
+---
+
+Introduce agent parameters to SDK constructor to allow greater networking control from the Node SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @evervault/sdk
 
-## 6.4.0
-
-### Minor Changes
-
-- d71783e: Introduce agent parameters to SDK constructor to allow greater networking control from the Node SDK
-
-### Patch Changes
-
-- 9fb4f47: Bumping axios to fix vulnerability
-
 ## 6.3.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/sdk",
-  "version": "6.4.0",
+  "version": "6.3.4",
   "description": "Node.js SDK for Evervault",
   "main": "lib/index.js",
   "typings": "types/index.d.ts",


### PR DESCRIPTION
Reverts evervault/evervault-node#225

NPM token in the release workflow is expired causing releases to fail. Need to revert the release to re-run with the updated secret from #231 