### PR TITLE
chore: replace uuid dependency with node:crypto randomUUID

### DIFF
--- a/e2e/outboundRelay.test.js
+++ b/e2e/outboundRelay.test.js
@@ -4,7 +4,7 @@ const {
   http: { proxiedMarker, certHostname },
 } = require('../lib/config');
 const axios = require('axios');
-const { v4 } = require('uuid');
+const { randomUUID } = require('node:crypto');
 
 describe('Outbound Relay Test', () => {
   const appUuid = process.env.EV_APP_UUID;
@@ -28,7 +28,7 @@ describe('Outbound Relay Test', () => {
 
       await evervaultClient.enableOutboundRelay();
       const response = await axios.post(
-        `${syntheticEndpointUrl}?syntheticUuid=${v4()}&mode=outbound`,
+        `${syntheticEndpointUrl}?syntheticUuid=${randomUUID()}&mode=outbound`,
         encrypted
       );
       const body = response.data;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "asn1js": "^3.0.5",
         "async-retry": "^1.3.3",
         "axios": "^1.12.0",
-        "crc-32": "^1.2.2",
-        "uuid": "^8.1.0"
+        "crc-32": "^1.2.2"
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.2",
@@ -5545,6 +5544,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "asn1js": "^3.0.5",
     "async-retry": "^1.3.3",
     "crc-32": "^1.2.2",
-    "uuid": "^8.1.0",
     "axios": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed
Removed the direct `uuid` npm dependency and replaced its only usage with `randomUUID` from `node:crypto` (built-in, no dependency needed).

- `e2e/outboundRelay.test.js`: `const { v4 } = require('uuid')` → `const { randomUUID } = require('node:crypto')`; `v4()` → `randomUUID()` (CJS, matching the file's existing module system).
- `package.json`: removed `"uuid": "^8.1.0"` from `dependencies`. (`@types/uuid` was not present.)
- `package-lock.json`: regenerated with `npm install --package-lock-only --ignore-scripts`. The `uuid` entry now remains only as a transitive **dev** dependency (via `istanbul-lib-processinfo`, used by the `nyc` coverage tooling) — it is no longer a direct/production dependency.

## Unmigrated
None. The single usage was `v4()`, which maps directly to `randomUUID()`. No `v1/v3/v5/NIL/parse/stringify/validate/version` usages were found.

## Lockfile status
Updated successfully. `--ignore-scripts` was required because the `prepare` (husky install) script is unavailable in this environment; the dependency-tree changes themselves resolved cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)