### PR TITLE
ci: accept main as well as master in workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: ['master']
+    branches: ['master', 'main']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ['master']
+    branches: ['master', 'main']
   schedule:
     - cron: '17 19 * * 1'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '**'
       - '!master'
+      - '!main'
 
 jobs:
   run-tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
 jobs:
   changesets:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: master
+    branches: [master, main]
 
 jobs:
   run-tests:


### PR DESCRIPTION
Preflight for the org-wide default branch rename to `main`.

Workflow triggers now match both `master` and `main`, so nothing stops
firing during the rename. The `master` entries are removed in the follow-up
cleanup PR after the default branch has been flipped.